### PR TITLE
issues with "Use" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ See [tags][releases] for other specific FHIR versions.
 
 1. Copy the file `settings.py` from the language's subdirectory into the project's root directory, 
 2. Adjust settings, if necessary
-3. Execute `./generate.py` to run the script.
+3. Install required libraries by running `pip install -r requirements.txt`
+4. Execute `./generate.py` to run the script.
     This will use Python _3_, issue `python generate.py` if you don't have Python 3 yet.
     Supply the `-f` flag to force a re-download of the spec.
 
@@ -64,6 +65,9 @@ Dates are expressed as `FHIRDate` instances which can parse valid ISO dates.
 ### Requirements ###
 
 ```text
+Jinja2>=2.7
+MarkupSafe==0.23
+requests
 isodate
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Jinja2>=2.7
 MarkupSafe==0.23
+requests
+isodate
+


### PR DESCRIPTION
fixes:
- no mention of installing libraries listed in requirements.txt
- requirements.txt not including all needed libraries
- "Requirements" section of README missing other libraries