### PR TITLE
Create 4th Generator Template Directory for Supporting Realm

### DIFF
--- a/Python/mappings.py
+++ b/Python/mappings.py
@@ -65,6 +65,12 @@ starexpandtypes = {
 # Which class names are native to the language (or can be treated this way)
 natives = ['bool', 'int', 'float', 'str', 'dict']
 
+# Which classes are primitives and don't support the RealmSwift.List<> without an Object wrapper
+primitives = []
+
+# which class names require to be wrapped in RealmOptional
+realm_optionals = []
+
 # Which classes are to be expected from JSON decoding
 jsonmap = {
     'str': 'str',

--- a/Swift3Realm/DateAndTime.swift
+++ b/Swift3Realm/DateAndTime.swift
@@ -1,0 +1,857 @@
+//
+//  DateAndTime.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 1/17/15.
+//  2015, SMART Health IT.
+//
+
+import Foundation
+import RealmSwift
+
+/**
+A protocol for all our date and time structs.
+*/
+protocol DateAndTime: CustomStringConvertible, Comparable, Equatable, RealmOptionalType {
+	
+	var nsDate: Date { get }
+}
+
+/**
+A date for use in human communication. Named `FHIRDate` to avoid the numerous collisions with `Foundation.Date`.
+
+Month and day are optional and there are no timezones.
+*/
+final public class FHIRDate: Object, DateAndTime {
+	
+	/// The year.
+	public dynamic var year: Int = Calendar.current.component(.year, from: Date())
+		
+    private let _month = RealmOptional<Int8>()
+    /// The month of the year, maximum of 12.
+    public var month: Int8? {
+        get {
+            return _month.value
+        }
+        set {
+            guard 1...12 ~= (newValue ?? 0) else {
+                _month.value = nil
+                return
+            }
+            
+            _month.value = newValue
+        }
+    }
+	
+    private let _day = RealmOptional<Int8>()
+	/// The day of the month; must be valid for the month (not enforced in code!).
+	public var day: Int8? {
+        get {
+            return _day.value
+        }
+        set {
+            guard 1...31 ~= (newValue ?? 0) else {
+                _day.value = nil
+                return
+            }
+            
+            _day.value = newValue
+        }
+	}
+	
+	
+	/**
+	Dedicated initializer. Everything but the year is optional, invalid months or days will be ignored (however it is NOT checked whether
+	the given month indeed contains the given day).
+	
+	- parameter year:  The year of the date
+	- parameter month: The month of the year
+	- parameter day:   The day of the month – your responsibility to ensure the month has the desired number of days; ignored if no month is
+	                   given
+	*/
+	convenience public init(year: Int, month: Int8?, day: Int8?) {
+        self.init()
+		self.year = year
+        self.month = month
+        self.day = day
+	}
+	
+	/**
+	Initializes a date with our `DateAndTimeParser`.
+	
+	Will fail unless the string contains at least a valid year.
+	
+	- parameter string: The string to parse the date from
+	*/
+	convenience public init?(string: String) {
+        self.init()
+		let parsed = DateAndTimeParser.sharedParser.parse(string: string)
+		if nil == parsed.date {
+			return nil
+		}
+		year = parsed.date!.year
+		month = parsed.date!.month
+		day = parsed.date!.day
+	}
+	
+	/**
+	- returns: Today's date
+	*/
+	public static var today: FHIRDate {
+		let (date, _, _) = DateNSDateConverter.sharedConverter.parse(date: Date())
+		return date
+	}
+	
+	
+	// MARK: Protocols
+	
+	public var nsDate: Date {
+		return DateNSDateConverter.sharedConverter.create(fromDate: self)
+	}
+	
+	override public var description: String {
+		if let m = month {
+			if let d = day {
+				return String(format: "%04d-%02d-%02d", year, m, d)
+			}
+			return String(format: "%04d-%02d", year, m)
+		}
+		return String(format: "%04d", year)
+	}
+	
+	public static func <(lhs: FHIRDate, rhs: FHIRDate) -> Bool {
+		if lhs.year == rhs.year {
+			guard let lhm = lhs.month else {
+				return true
+			}
+			guard let rhm = rhs.month else {
+				return false
+			}
+			if lhm == rhm {
+				guard let lhd = lhs.day else {
+					return true
+				}
+				guard let rhd = rhs.day else {
+					return false
+				}
+				return lhd < rhd
+			}
+			return lhm < rhm
+		}
+		return lhs.year < rhs.year
+	}
+	
+	public static func ==(lhs: FHIRDate, rhs: FHIRDate) -> Bool {
+		return lhs.year == rhs.year
+			&& lhs.month == rhs.month
+			&& lhs.day == rhs.day
+	}
+}
+
+/**
+A time during the day, optionally with seconds, usually for human communication. Named `FHIRTime` to match with `FHIRDate`.
+
+Minimum of 00:00 and maximum of < 24:00. There is no timezone. Since decimal precision has significance in FHIR, Time initialized from a
+string will remember the seconds string until it is manually set.
+*/
+final public class FHIRTime: Object, DateAndTime {
+	
+    /// The hour of the day; cannot be higher than 23.
+    public dynamic var hour: Int8 = 0 {
+        didSet {
+            if hour < 0 { hour = 0 }
+            if hour > 23 { hour = 23 }
+        }
+    }
+		
+	/// The minute of the hour; cannot be larger than 59
+    public dynamic var minute: Int8 = 0 {
+        didSet {
+            if minute < 0 { minute = 0 }
+            if minute > 59 { minute = 59 }
+        }
+    }
+	
+	/// The second of the minute; must be smaller than 60
+    public dynamic var second: Double = 0.0 {
+        didSet {
+            if second < 0 { second = 0 }
+            if second >= 60.0 { second = 59.999999999 }
+        }
+    }
+	
+	/// If initialized from string, this was the string for the seconds; we use this to remember precision.
+	public internal(set) var tookSecondsFromString: String?
+	
+	/**
+	Dedicated initializer. Overflows seconds and minutes to arrive at the final time, which must be less than 24:00:00 or it will be capped.
+	
+	The `secondsFromString` parameter will be discarded if it is negative or higher than 60.
+	
+	- parameter hour:              Hour of day, cannot be greater than 23 (a time of 24:00 is illegal)
+	- parameter minute:            Minutes of the hour; if greater than 59 will roll over into hours
+	- parameter second:            Seconds of the minute; if 60 or more will roll over into minutes and discard `secondsFromString`
+	- parameter secondsFromString: If time was initialized from a string, you can provide the seconds string here to ensure precision is
+	                               kept. You are responsible to ensure that this string actually represents what's passed into `seconds`.
+	*/
+	public convenience init(hour: UInt8, minute: UInt8, second: Double, secondsFromString: String? = nil) {
+        self.init()
+		var overflowMinute: UInt = 0
+		var overflowHour: UInt = 0
+		
+		if second >= 0.0 {
+			if second >= 60.0 {
+				self.second = second.truncatingRemainder(dividingBy: 60)
+				overflowMinute = UInt((second - self.second) / 60)
+			}
+			else {
+				self.second = second
+				self.tookSecondsFromString = secondsFromString
+			}
+		}
+		
+		let mins = UInt(minute) + overflowMinute
+		if mins > 59 {
+			self.minute = Int8(UInt8(mins % 60))
+			overflowHour = (mins - (mins % 60)) / 60
+		}
+		else {
+			self.minute = Int8(mins)
+		}
+		
+		let hrs = UInt(hour) + overflowHour
+		if hrs > 23 {
+			self.hour = 23
+			self.minute = 59
+			self.second = 59.999999999
+			self.tookSecondsFromString = nil
+		}
+		else {
+			self.hour = Int8(hrs)
+		}
+	}
+	
+	/**
+	Initializes a time from a time string by passing it through `DateAndTimeParser`.
+	
+	Will fail unless the string contains at least hour and minute.
+	*/
+	public convenience init?(string: String) {
+        self.init()
+		let parsed = DateAndTimeParser.sharedParser.parse(string: string, isTimeOnly: true)
+		guard let time = parsed.time else {
+			return nil
+		}
+		hour = time.hour
+		minute = time.minute
+		second = time.second
+		tookSecondsFromString = time.tookSecondsFromString
+	}
+	
+	/**
+	The time right now.
+	
+	- returns: The clock time of right now.
+	*/
+	public static var now: FHIRTime {
+		let (_, time, _) = DateNSDateConverter.sharedConverter.parse(date: Date())
+		return time
+	}
+	
+	
+	// MARK: Protocols
+	
+	public var nsDate: Date {
+		return DateNSDateConverter.sharedConverter.create(fromTime: self)
+	}
+	
+	// TODO: this implementation uses a workaround using string coercion instead of format: "%02d:%02d:%@" because %@ with String is not
+	// supported on Linux (SR-957)
+	public override var description: String {
+		if let secStr = tookSecondsFromString {
+			#if os(Linux)
+			return String(format: "%02d:%02d:", hour, minute) + secStr
+			#else
+			return String(format: "%02d:%02d:%@", hour, minute, secStr)
+			#endif
+		}
+		
+        #if os(Linux)
+            return String(format: "%02d:%02d:", hour, minute) + ((second < 10) ? "0" : "") + String(format: "%g", s)
+        #else
+            return String(format: "%02d:%02d:%@%g", hour, minute, (second < 10) ? "0" : "", second)
+        #endif
+	}
+	
+	public static func <(lhs: FHIRTime, rhs: FHIRTime) -> Bool {
+		if lhs.hour == rhs.hour {
+			if lhs.minute == rhs.minute {
+                if lhs.second == rhs.second {
+                    return false
+                }
+				return lhs.second < rhs.second
+			}
+			return lhs.minute < rhs.minute
+		}
+		return lhs.hour < rhs.hour
+	}
+	
+	public static func ==(lhs: FHIRTime, rhs: FHIRTime) -> Bool {
+        return lhs.description == rhs.description
+	}
+}
+
+
+/**
+A date, optionally with time, as used in human communication.
+
+If a time is specified there must be a timezone; defaults to the system reported local timezone.
+*/
+final public class DateTime: Object, DateAndTime {
+	
+	/// The date.
+	public dynamic var date: FHIRDate?
+	
+	/// The time.
+	public dynamic var time: FHIRTime?
+	
+	/// The timezone
+    public var timeZone: TimeZone? {
+        didSet {
+            timeZoneString = nil;
+        }
+    }
+	
+    /// The timezone string seen during deserialization; to be used on serialization unless the timezone changed.
+	private dynamic var timeZoneString: String?
+	
+    public override class func ignoredProperties() -> [String] {
+        return ["timeZone", "nsDate"]
+    }
+    
+	/**
+	This very date and time.
+	
+	- returns: A DateTime instance representing current date and time.
+	*/
+	public static var now: DateTime {
+		let (date, time, tz) = DateNSDateConverter.sharedConverter.parse(date: Date())
+		return DateTime(date: date, time: time, timeZone: tz)
+	}
+	
+	/**
+	Designated initializer, takes a date and optionally a time and a timezone.
+	
+	If time is given but no timezone, the instance is assigned the local time zone.
+	
+	- parameter date:     The date of the date-time
+	- parameter time:     The time of the date-time
+	- parameter timeZone: The timezone
+	*/
+	public convenience init(date: FHIRDate, time: FHIRTime?, timeZone: TimeZone?) {
+        self.init()
+		self.date = date
+		self.time = time
+		if nil != time && nil == timeZone {
+			self.timeZone = TimeZone.current
+		}
+		else {
+			self.timeZone = timeZone
+		}
+	}
+	
+	/**
+	Uses `DateAndTimeParser` to initialize from a date-time string.
+	
+	If time is given but no timezone, the instance is assigned the local time zone.
+	
+	- parameter string: The string the date-time is parsed from
+	*/
+	public convenience init?(string: String) {
+        self.init()
+		let (date, time, tz, tzString) = DateAndTimeParser.sharedParser.parse(string: string)
+		if nil == date {
+			return nil
+		}
+		self.date = date!
+		if let time = time {
+			self.time = time
+			self.timeZone = tz ?? TimeZone.current
+			self.timeZoneString = tzString
+		}
+	}
+	
+	
+	// MARK: Protocols
+	public var nsDate: Date {
+		if let time = time, let tz = timeZone {
+			return DateNSDateConverter.sharedConverter.create(date: date ?? FHIRDate.today, time: time, timeZone: tz)
+		}
+		return DateNSDateConverter.sharedConverter.create(fromDate: date ?? FHIRDate.today)
+	}
+	
+	public override var description: String {
+		if let tm = time {
+			if let tz = timeZoneString ?? timeZone?.offset() {
+				return "\(date?.description ?? FHIRDate.today.description)T\(tm.description)\(tz)"
+			}
+		}
+		return date?.description ?? FHIRDate.today.description
+	}
+	
+	public static func <(lhs: DateTime, rhs: DateTime) -> Bool {
+		let lhd = lhs.nsDate
+		let rhd = rhs.nsDate
+		return (lhd.compare(rhd) == .orderedAscending)
+	}
+	
+	public static func ==(lhs: DateTime, rhs: DateTime) -> Bool {
+		let lhd = lhs.nsDate
+		let rhd = rhs.nsDate
+		return (lhd.compare(rhd) == .orderedSame)
+	}
+}
+
+
+/**
+An instant in time, known at least to the second and with a timezone, for machine times.
+*/
+final public class Instant: Object, DateAndTime {
+	
+	/// The date.
+    private dynamic var _date: FHIRDate? = FHIRDate.today {
+        didSet {
+            if nil == _date?.month {
+                _date?.month = 1
+            }
+            if nil == _date?.day {
+                _date?.day = 1
+            }
+        }
+    }
+    
+    public var date: FHIRDate {
+        get {
+            return _date!
+        }
+        set {
+            _date = newValue
+        }
+    }
+	
+	/// The time, including seconds.
+	private dynamic var _time: FHIRTime? = FHIRTime.now
+    public var time: FHIRTime {
+        get {
+            return _time!
+        }
+        set {
+            _time = newValue
+        }
+    }
+	
+	/// The timezone.
+    public var timeZone: TimeZone = TimeZone.current {
+		didSet {
+			timeZoneString = nil
+		}
+	}
+	
+    public override class func ignoredProperties() -> [String] {
+        return ["timeZone", "date", "time"]
+    }
+    
+	/// The timezone string seen during deserialization; to be used on serialization unless the timezone changed.
+	private dynamic var timeZoneString: String?
+	
+	/**
+	This very instant.
+	
+	- returns: An Instant instance representing current date and time.
+	*/
+	public static var now: Instant {
+		let (date, time, tz) = DateNSDateConverter.sharedConverter.parse(date: Date())
+		return Instant(date: date, time: time, timeZone: tz)
+	}
+	
+	/**
+	Designated initializer.
+	
+	- parameter date:     The date of the instant; ensures to have month and day (which are optional in the `FHIRDate` construct)
+	- parameter time:     The time of the instant; ensures to have seconds (which are optional in the `FHIRTime` construct)
+	- parameter timeZone: The timezone
+	*/
+	public convenience init(date: FHIRDate, time: FHIRTime, timeZone: TimeZone) {
+        self.init()
+		self.date = date
+		if nil == self.date.month {
+			self.date.month = 1
+		}
+		if nil == self.date.day {
+			self.date.day = 1
+		}
+		self.time = time
+		self.timeZone = timeZone
+	}
+	
+	/** Uses `DateAndTimeParser` to initialize from a date-time string.
+	
+	- parameter string: The string to parse the instant from
+	*/
+	public convenience init?(string: String) {
+        self.init()
+		let (date, time, tz, tzString) = DateAndTimeParser.sharedParser.parse(string: string)
+		if nil == date || nil == date!.month || nil == date!.day || nil == time || nil == tz {
+			return nil
+		}
+		self.date = date!
+		self.time = time!
+		self.timeZone = tz!
+		self.timeZoneString = tzString!
+	}
+	
+	// MARK: Protocols
+	
+	public var nsDate: Date {
+		return DateNSDateConverter.sharedConverter.create(date: date, time: time, timeZone: timeZone)
+	}
+	
+	public override var description: String {
+		let tz = timeZoneString ?? timeZone.offset()
+		return "\(date.description)T\(time.description)\(tz)"
+	}
+	
+	public static func <(lhs: Instant, rhs: Instant) -> Bool {
+		let lhd = lhs.nsDate
+		let rhd = rhs.nsDate
+		return (lhd.compare(rhd) == .orderedAscending)
+	}
+	
+	public static func ==(lhs: Instant, rhs: Instant) -> Bool {
+		let lhd = lhs.nsDate
+		let rhd = rhs.nsDate
+		return (lhd.compare(rhd) == .orderedSame)
+	}
+}
+
+
+extension Instant {
+	
+	/**
+	Attempts to parse an Instant from RFC1123-formatted date strings, usually used by HTTP headers:
+	
+	- "EEE',' dd MMM yyyy HH':'mm':'ss z"
+	- "EEEE',' dd'-'MMM'-'yy HH':'mm':'ss z" (RFC850)
+	- "EEE MMM d HH':'mm':'ss yyyy"
+	
+	Created by taking liberally from Marcus Rohrmoser's blogpost at http://blog.mro.name/2009/08/nsdateformatter-http-header/
+	
+	- parameter httpDate: The date string to parse
+	- returns: An Instant if parsing was successful, nil otherwise
+	*/
+	public static func fromHttpDate(_ httpDate: String) -> Instant? {
+		let formatter = DateFormatter()
+		formatter.locale = Locale(identifier: "en_US_POSIX")
+		formatter.timeZone = TimeZone(abbreviation: "GMT")
+		formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss z"
+		if let date = formatter.date(from: httpDate) {
+			return date.fhir_asInstant()
+		}
+		
+		formatter.dateFormat = "EEEE',' dd'-'MMM'-'yy HH':'mm':'ss z"
+		if let date = formatter.date(from: httpDate) {
+			return date.fhir_asInstant()
+		}
+		
+		formatter.dateFormat = "EEE MMM d HH':'mm':'ss yyyy"
+		if let date = formatter.date(from: httpDate) {
+			return date.fhir_asInstant()
+		}
+		return nil
+	}
+}
+
+
+/**
+Converts between NSDate and our FHIRDate, FHIRTime, DateTime and Instance structs.
+*/
+class DateNSDateConverter {
+	
+	/// The singleton instance
+	static var sharedConverter = DateNSDateConverter()
+	
+	let calendar: Calendar
+	let utc: TimeZone
+	
+	init() {
+		utc = TimeZone(abbreviation: "UTC")!
+		var cal = Calendar(identifier: Calendar.Identifier.gregorian)
+		cal.timeZone = utc
+		calendar = cal
+	}
+	
+	
+	// MARK: Parsing
+	
+	/**
+	Execute parsing. Will use `calendar` to split the Date into components.
+	
+	- parameter date: The Date to parse into structs
+	- returns: A tuple with (FHIRDate, FHIRTime, TimeZone)
+	*/
+	func parse(date inDate: Date) -> (FHIRDate, FHIRTime, TimeZone) {
+		let flags: Set<Calendar.Component> = [.year, .month, .day, .hour, .minute, .second, .nanosecond, .timeZone]
+		let comp = calendar.dateComponents(flags, from: inDate)
+		
+		let date = FHIRDate(year: comp.year!, month: Int8(comp.month!), day: Int8(comp.day!))
+		let zone = comp.timeZone ?? utc
+		let secs = Double(comp.second!) + (Double(comp.nanosecond!) / 1000000000)
+		let time = FHIRTime(hour: UInt8(comp.hour!), minute: UInt8(comp.minute!), second: secs)
+		
+		return (date, time, zone)
+	}
+	
+	
+	// MARK: Creation
+	
+	func create(fromDate date: FHIRDate) -> Date {
+		return _create(date: date, time: nil, timeZone: nil)
+	}
+	
+	func create(fromTime time: FHIRTime) -> Date {
+		return _create(date: nil, time: time, timeZone: nil)
+	}
+	
+	func create(date: FHIRDate, time: FHIRTime, timeZone: TimeZone) -> Date {
+		return _create(date: date, time: time, timeZone: timeZone)
+	}
+	
+	func _create(date: FHIRDate?, time: FHIRTime?, timeZone: TimeZone?) -> Date {
+		var comp = DateComponents()
+		comp.timeZone = timeZone ?? utc
+		
+		if let yr = date?.year {
+			comp.year = yr
+		}
+		if let mth = date?.month {
+			comp.month = Int(mth)
+		}
+		if let d = date?.day {
+			comp.day = Int(d)
+		}
+		
+		if let hr = time?.hour {
+			comp.hour = Int(hr)
+		}
+		if let min = time?.minute {
+			comp.minute = Int(min)
+		}
+		if let sec = time?.second {
+			comp.second = Int(floor(sec))
+			comp.nanosecond = Int(sec.truncatingRemainder(dividingBy: 1000000000))
+		}
+		
+		return calendar.date(from: comp) ?? Date()
+	}
+}
+
+
+/**
+Parses Date and Time from strings in a narrow set of the extended ISO 8601 format.
+*/
+class DateAndTimeParser {
+	
+	/// The singleton instance
+	static var sharedParser = DateAndTimeParser()
+	
+	/**
+	Parses a date string in "YYYY[-MM[-DD]]" and a time string in "hh:mm[:ss[.sss]]" (extended ISO 8601) format,
+	separated by "T" and followed by either "Z" or a valid time zone offset in the "±hh[:?mm]" format.
+	
+	Does not currently check if the day exists in the given month.
+	
+	- parameter string:     The date string to parse
+	- parameter isTimeOnly: If true assumes that the string describes time only
+	- returns:              A tuple with (FHIRDate?, FHIRTime?, TimeZone?, String? [for time zone])
+	*/
+	func parse(string: String, isTimeOnly: Bool=false) -> (date: FHIRDate?, time: FHIRTime?, tz: TimeZone?, tzString: String?) {
+		let scanner = Scanner(string: string)
+		var date: FHIRDate?
+		var time: FHIRTime?
+		var tz: TimeZone?
+		var tzString: String?
+		
+		// scan date (must have at least the year)
+		if !isTimeOnly {
+			if let year = scanner.fhir_scanInt(), year < 10000 {			// dates above 9999 are considered special cases
+				if nil != scanner.fhir_scanString("-"), let month = scanner.fhir_scanInt(), month <= 12 {
+					if nil != scanner.fhir_scanString("-"), let day = scanner.fhir_scanInt(), day <= 31 {
+						date = FHIRDate(year: Int(year), month: Int8(month), day: Int8(day))
+					}
+					else {
+						date = FHIRDate(year: Int(year), month: Int8(month), day: nil)
+					}
+				}
+				else {
+					date = FHIRDate(year: Int(year), month: nil, day: nil)
+				}
+			}
+		}
+		
+		// scan time
+		if isTimeOnly || nil != scanner.fhir_scanString("T") {
+			if let hour = scanner.fhir_scanInt(), hour >= 0 && hour < 24 && nil != scanner.fhir_scanString(":"),
+				let minute = scanner.fhir_scanInt(), minute >= 0 && minute < 60 {
+				
+				let digitSet = CharacterSet.decimalDigits
+				var decimalSet = NSMutableCharacterSet.decimalDigits
+				decimalSet.insert(".")
+				
+				if nil != scanner.fhir_scanString(":"), let secStr = scanner.fhir_scanCharacters(from: decimalSet as CharacterSet), let second = Double(secStr), second < 60.0 {
+					time = FHIRTime(hour: UInt8(hour), minute: UInt8(minute), second: second, secondsFromString: secStr)
+				}
+				else {
+					time = FHIRTime(hour: UInt8(hour), minute: UInt8(minute), second: 0)
+				}
+				
+				// scan zone
+				if !scanner.fhir_isAtEnd {
+					if nil != scanner.fhir_scanString("Z") {
+						tz = TimeZone(abbreviation: "UTC")
+						tzString = "Z"
+					}
+					else if var tzStr = (scanner.fhir_scanString("-") ?? scanner.fhir_scanString("+")) {
+						if let hourStr = scanner.fhir_scanCharacters(from: digitSet) {
+							tzStr += hourStr
+							var tzhour = 0
+							var tzmin = 0
+							if 2 == hourStr.characters.count {
+								tzhour = Int(hourStr) ?? 0
+								if nil != scanner.fhir_scanString(":"), let tzm = scanner.fhir_scanInt() {
+									tzStr += (tzm < 10) ? ":0\(tzm)" : ":\(tzm)"
+									if tzm < 60 {
+										tzmin = tzm
+									}
+								}
+							}
+							else if 4 == hourStr.characters.count {
+								tzhour = Int(hourStr.substring(to: hourStr.index(hourStr.startIndex, offsetBy: 2)))!
+								tzmin = Int(hourStr.substring(from: hourStr.index(hourStr.startIndex, offsetBy: 2)))!
+							}
+							
+							let offset = tzhour * 3600 + tzmin * 60
+							tz = TimeZone(secondsFromGMT:tzStr.hasPrefix("+") ? offset : -1 * offset)
+							tzString = tzStr
+						}
+					}
+				}
+			}
+		}
+		
+		return (date, time, tz, tzString)
+	}
+}
+
+
+/**
+Extend Date to be able to return DateAndTime instances.
+*/
+public extension Date {
+	
+	/** Create a `FHIRDate` instance from the receiver. */
+	func fhir_asDate() -> FHIRDate {
+		let (date, _, _) = DateNSDateConverter.sharedConverter.parse(date: self)
+		return date
+	}
+	
+	/** Create a `Time` instance from the receiver. */
+	func fhir_asTime() -> FHIRTime {
+		let (_, time, _) = DateNSDateConverter.sharedConverter.parse(date: self)
+		return time
+	}
+	
+	/** Create a `DateTime` instance from the receiver. */
+	func fhir_asDateTime() -> DateTime {
+		let (date, time, tz) = DateNSDateConverter.sharedConverter.parse(date: self)
+		return DateTime(date: date, time: time, timeZone: tz)
+	}
+	
+	/** Create an `Instance` instance from the receiver. */
+	func fhir_asInstant() -> Instant {
+		let (date, time, tz) = DateNSDateConverter.sharedConverter.parse(date: self)
+		return Instant(date: date, time: time, timeZone: tz)
+	}
+}
+
+
+/**
+Extend TimeZone to report the offset in "+00:00" or "Z" (for UTC/GMT) format.
+*/
+extension TimeZone {
+	
+	/**
+	Return the offset as a string string.
+	
+	- returns: The offset as a string; uses "Z" if the timezone is UTC or GMT
+	*/
+	func offset() -> String {
+		if "UTC" == identifier || "GMT" == identifier {
+			return "Z"
+		}
+		
+		let secsFromGMT = secondsFromGMT()
+		let hr = abs((secsFromGMT / 3600) - (secsFromGMT % 3600))
+		let min = abs((secsFromGMT % 3600) / 60)
+		
+		return (secsFromGMT >= 0 ? "+" : "-") + String(format: "%02d:%02d", hr, min)
+	}
+}
+
+
+/**
+Extend Scanner to account for interface differences between macOS and Linux (as of November 2016)
+*/
+extension Scanner {
+	
+	public var fhir_isAtEnd: Bool {
+		#if os(Linux)
+		return atEnd
+		#else
+		return isAtEnd
+		#endif
+	}
+	
+	public func fhir_scanString(_ searchString: String) -> String? {
+		#if os(Linux)
+		return scanString(string: searchString)
+		#else
+		var str: NSString?
+		if scanString(searchString, into: &str) {
+			return str as? String
+		}
+		return nil
+		#endif
+	}
+	
+	public func fhir_scanCharacters(from set: CharacterSet) -> String? {
+		#if os(Linux)
+		return scanCharactersFromSet(set)
+		#else
+		var str: NSString?
+		if scanCharacters(from: set, into: &str) {
+			return str as? String
+		}
+		return nil
+		#endif
+	}
+	
+	public func fhir_scanInt() -> Int? {
+		var int = 0
+		#if os(Linux)
+		let flag = scanInteger(&int)
+		#else
+		let flag = scanInt(&int)
+		#endif
+		return flag ? int : nil
+	}
+}

--- a/Swift3Realm/DateAndTimeTests.swift
+++ b/Swift3Realm/DateAndTimeTests.swift
@@ -1,0 +1,625 @@
+//
+//  DateAndTimeTests.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 1/19/15.
+//  2015, SMART Health IT.
+//
+
+import XCTest
+@testable import RealmSwiftFHIR
+
+
+class DateTests: XCTestCase {
+	
+	func testParsing() {
+		var d = FHIRDate(string: "2015")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.year)
+		XCTAssertTrue(nil == d!.month)
+		XCTAssertTrue(nil == d!.day)
+		
+		d = FHIRDate(string: "2015-83")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.year)
+		XCTAssertTrue(nil == d!.month)
+		XCTAssertTrue(nil == d!.day)
+		
+		d = FHIRDate(string: "2015-03")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.year)
+		XCTAssertEqual(Int8(3), d!.month!)
+		XCTAssertTrue(nil == d!.day)
+		
+		d = FHIRDate(string: "2015-03-54")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.year)
+		XCTAssertEqual(Int8(3), d!.month!)
+		XCTAssertTrue(nil == d!.day)
+		
+		d = FHIRDate(string: "2015-03-28")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.year)
+		XCTAssertEqual(Int8(3), d!.month!)
+		XCTAssertEqual(Int8(28), d!.day!)
+		
+		d = FHIRDate(string: "abc")
+		XCTAssertTrue(nil == d)
+		
+		d = FHIRDate(string: "201512")
+		XCTAssertTrue(nil == d)
+		
+		d = FHIRDate(string: "2015-123-456")!
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.year)
+		XCTAssertTrue(nil == d!.month)
+		XCTAssertTrue(nil == d!.day)
+	}
+	
+	func testComparisons() {
+		var a = FHIRDate(string: "2014")!
+		var b = FHIRDate(string: "1914")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRDate(string: "2014-12")!
+		b = FHIRDate(string: "2014-11")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRDate(string: "2014-11-25")!
+		b = FHIRDate(string: "2014-11-24")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRDate(string: "2014-11-24")!
+		b = FHIRDate(string: "1914-11-24")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRDate(string: "2014-12-24")!
+		b = FHIRDate(string: "2014-11-24")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+	}
+	
+	func testConversion() {
+		let date = FHIRDate(string: "1981-03-28")!
+		let ns = date.nsDate
+        XCTAssertTrue(date == ns.fhir_asDate(), "Conversion to NSDate and back again must not alter `Date`")
+	}
+}
+
+
+class TimeTests: XCTestCase {
+	
+	func testParsing() {
+		var t = FHIRTime(string: "18")
+		XCTAssertTrue(nil == t)
+		
+		t = FHIRTime(string: "18:72")
+		XCTAssertTrue(nil == t)
+		
+		t = FHIRTime(string: "25:44")
+		XCTAssertTrue(nil == t)
+		
+		t = FHIRTime(string: "18:44")
+		XCTAssertFalse(nil == t)
+		XCTAssertEqual(Int8(18), t!.hour)
+		XCTAssertEqual(Int8(44), t!.minute)
+		XCTAssertTrue(0 == t!.second)
+		
+		t = FHIRTime(string: "00:00:00")
+		XCTAssertFalse(nil == t)
+		XCTAssertEqual(Int8(0), t!.hour)
+		XCTAssertEqual(Int8(0), t!.minute)
+		XCTAssertEqual(0.0, t!.second)
+		
+		t = FHIRTime(string: "18:44:88")
+		XCTAssertFalse(nil == t)
+		XCTAssertEqual(Int8(18), t!.hour)
+		XCTAssertEqual(Int8(44), t!.minute)
+		XCTAssertTrue(0 == t!.second)
+		
+		t = FHIRTime(string: "18:44:-4")
+		XCTAssertFalse(nil == t)
+		XCTAssertEqual(Int8(18), t!.hour)
+		XCTAssertEqual(Int8(44), t!.minute)
+		XCTAssertTrue(0 == t!.second)
+		
+		t = FHIRTime(string: "18:44:02")
+		XCTAssertFalse(nil == t)
+		XCTAssertEqual(Int8(18), t!.hour)
+		XCTAssertEqual(Int8(44), t!.minute)
+		XCTAssertEqual(2.0, t!.second)
+		
+		t = FHIRTime(string: "18:44:02.2912")
+		XCTAssertFalse(nil == t)
+		XCTAssertEqual(Int8(18), t!.hour)
+		XCTAssertEqual(Int8(44), t!.minute)
+		XCTAssertEqual(2.2912, t!.second)
+		
+		t = FHIRTime(string: "18:74:28.0381")
+		XCTAssertTrue(nil == t)
+		
+		t = FHIRTime(string: "18:-32:28.0381")
+		XCTAssertTrue(nil == t)
+		
+		t = FHIRTime(string: "18:44:-28.0381")
+		XCTAssertFalse(nil == t)
+		XCTAssertEqual(Int8(18), t!.hour)
+		XCTAssertEqual(Int8(44), t!.minute)
+		XCTAssertTrue(0 == t!.second)
+		
+		t = FHIRTime(string: "18:44:28.038100")
+		XCTAssertFalse(nil == t)
+		XCTAssertEqual(Int8(18), t!.hour)
+		XCTAssertEqual(Int8(44), t!.minute)
+		XCTAssertEqual(28.0381, t!.second)
+		XCTAssertEqual(t!.description, "18:44:28.038100", "must preserve precision")
+		
+		t = FHIRTime(string: "abc")
+		XCTAssertTrue(nil == t)
+	}
+	
+	func testComparisons() {
+		var a = FHIRTime(string: "19:12")!
+		var b = FHIRTime(string: "19:11")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRTime(string: "19:11:04")!
+		b = FHIRTime(string: "19:11:03")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRTime(string: "19:11:04")!
+		b = FHIRTime(string: "07:11:05")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRTime(string: "19:00:04")!
+		b = FHIRTime(string: "07:11:05")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRTime(string: "19:11:04")!
+		b = FHIRTime(string: "19:11")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRTime(string: "19:11:04.0002")!
+		b = FHIRTime(string: "19:11:04")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = FHIRTime(string: "19:11:04.0002")!
+		b = FHIRTime(hour: 19, minute: 11, second: 4.0002)
+		XCTAssertFalse(a > b)
+		XCTAssertTrue(a == b)
+		
+		a = FHIRTime(string: "19:11:04.000200")!
+		b = FHIRTime(hour: 19, minute: 11, second: 4.0002)
+		XCTAssertFalse(a > b)
+		XCTAssertFalse(a < b)
+		XCTAssertFalse(a == b)
+	}
+	
+	func testConversion() {
+		let time = FHIRTime(string: "15:42:03")!
+		let ns = time.nsDate
+        XCTAssertTrue(time == ns.fhir_asTime(), "Conversion to NSDate and back again must not alter `Time`")
+	}
+}
+
+
+class DateTimeTests: XCTestCase {
+	
+	func testParseAllCorrect() {
+		var d = DateTime(string: "2015")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertTrue(nil == d!.date?.month)
+		XCTAssertTrue(nil == d!.time)
+		XCTAssertTrue(nil == d!.timeZone)
+		
+		d = DateTime(string: "2015-03")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertTrue(nil == d!.date?.day)
+		XCTAssertTrue(nil == d!.time)
+		XCTAssertTrue(nil == d!.timeZone)
+		
+		d = DateTime(string: "2015-03-28")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertTrue(nil == d!.time)
+		XCTAssertTrue(nil == d!.timeZone)
+		
+		d = DateTime(string: "2015-03-28T02:33")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertTrue(0 == d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertEqual(TimeZone.current, d!.timeZone!, "Must default to the local timezone")
+		
+		d = DateTime(string: "2015-03-28T02:33:29")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertEqual(TimeZone.current, d!.timeZone!, "Should default to local time zone but have \(d!.timeZone)")
+		
+		d = DateTime(string: "2015-03-28T02:33:29+01:00")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertTrue(3600 == d!.timeZone!.secondsFromGMT(), "Should be 3600 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
+		
+		d = DateTime(string: "2015-03-28T02:33:29-05:00")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
+		
+		d = DateTime(string: "2015-03-28T02:33:29.1285-05:00")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29.1285, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
+		
+		d = DateTime(string: "2015-03-28T02:33:29.1285-05:30")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29.1285, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertTrue(-19800 == d!.timeZone!.secondsFromGMT(), "Should be 19800 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
+		
+		d = DateTime(string: "2015-03-28T02:33:29.128500-05:30")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29.1285, d!.time!.second)
+		XCTAssertEqual("2015-03-28T02:33:29.128500-05:30", d!.description)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertTrue(-19800 == d!.timeZone!.secondsFromGMT(), "Should be 19800 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
+		
+		d = DateTime(string: "2015-03-28T02:33:29-05")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
+		
+		d = DateTime(string: "2015-03-28T02:33:29.1285-0500")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29.1285, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
+		
+		d = DateTime(string: "2015-03-28T02:33:29.1285-0530")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29.1285, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertTrue(-19800 == d!.timeZone!.secondsFromGMT(), "Should be 19800 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
+	}
+	
+	func testParseSomeFails() {
+		var d: DateTime?
+//		d = DateTime(string: "02015")	// should probably fail, currently doesn't
+//		XCTAssertTrue(nil == d)
+		
+		d = DateTime(string: "2015-103")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertTrue(nil == d!.date?.month)
+		XCTAssertTrue(nil == d!.date?.day)
+		XCTAssertTrue(nil == d!.time)
+		XCTAssertTrue(nil == d!.timeZone)
+		
+		d = DateTime(string: "2015-03-208")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertTrue(nil == d!.date?.day)
+		XCTAssertTrue(nil == d!.time)
+		XCTAssertTrue(nil == d!.timeZone)
+		
+		d = DateTime(string: "2015-03-28 02:33")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertTrue(nil == d!.time)
+		XCTAssertTrue(nil == d!.timeZone)
+		
+		d = DateTime(string: "2015-03-28T02-33-29")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertTrue(nil == d!.time)
+		XCTAssertTrue(nil == d!.timeZone)
+		
+		d = DateTime(string: "2015-03-28T02:33:29GMT")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date?.year)
+		XCTAssertEqual(Int8(3), d!.date?.month!)
+		XCTAssertEqual(Int8(28), d!.date?.day!)
+		XCTAssertFalse(nil == d!.time)
+		XCTAssertEqual(Int8(2), d!.time!.hour)
+		XCTAssertEqual(Int8(33), d!.time!.minute)
+		XCTAssertEqual(29, d!.time!.second)
+		XCTAssertFalse(nil == d!.timeZone)
+		XCTAssertEqual(TimeZone.current, d!.timeZone!, "Should default to local time zone but have \(d!.timeZone)")
+	}
+	
+	func testComparisons() {
+		var a = DateTime(string: "2014")!
+		var b = DateTime(string: "1914")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = DateTime(string: "2015-03-28T03:11")!
+		b = DateTime(string: "2015-03-28T03:10")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = DateTime(string: "2015-03-28T03:11:04")!
+		b = DateTime(string: "2015-03-28T03:11:03")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = DateTime(string: "2015-03-28T03:11:04")!
+		b = DateTime(string: "2015-03-28T03:11:04")!
+		XCTAssertFalse(a > b)
+		XCTAssertTrue(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = DateTime(string: "2015-03-28T03:11:04Z")!
+		b = DateTime(string: "1915-03-28T03:11:04Z")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = DateTime(string: "2015-03-28T03:11:04Z")!
+		b = DateTime(string: "2015-03-28T03:11:04+00:00")!
+		XCTAssertFalse(a > b)
+		XCTAssertTrue(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = DateTime(string: "2015-03-28T03:11+00:00")!
+		b = DateTime(string: "2015-03-28T03:17+01:00")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = DateTime(string: "2015-03-27T22:12:44-05:00")!
+		b = DateTime(string: "2015-03-28T03:12:43-00:00")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = DateTime(string: "2015-03-28T05:11:44.3+01:00")!
+		b = DateTime(string: "2015-03-27T23:11:44.3-05:00")!
+		XCTAssertFalse(a > b)
+		XCTAssertTrue(a == b)
+		XCTAssertTrue(a == a)
+	}
+	
+	func testConversion() {
+		let dt = DateTime(string: "1981-03-28T15:42:03")!
+		let ns = dt.nsDate
+        XCTAssertTrue(dt == ns.fhir_asDateTime(), "Conversion to NSDate and back again must not alter `DateTime`")
+		
+		let dt2 = DateTime(string: "1981-03-28T15:42:03-0100")!
+		let ns2 = dt2.nsDate
+        XCTAssertTrue(dt2 == ns2.fhir_asDateTime(), "Conversion to NSDate and back again must not alter `DateTime`")		
+	}
+}
+
+
+class InstantTests: XCTestCase {
+	
+	func testParseSuccess() {
+		var d = Instant(string: "2015")
+		XCTAssertTrue(nil == d)
+		
+		d = Instant(string: "2015-03")
+		XCTAssertTrue(nil == d)
+		
+		d = Instant(string: "2015-03-28")
+		XCTAssertTrue(nil == d)
+		
+		d = Instant(string: "2015-03-28T02:33")
+		XCTAssertTrue(nil == d)
+		
+		d = Instant(string: "2015-03-28T02:33:29")
+		XCTAssertTrue(nil == d)
+		
+		d = Instant(string: "2015-03-28T02:33:29+01:00")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date.year)
+		XCTAssertEqual(Int8(3), d!.date.month!)
+		XCTAssertEqual(Int8(28), d!.date.day!)
+		XCTAssertEqual(Int8(2), d!.time.hour)
+		XCTAssertEqual(Int8(33), d!.time.minute)
+		XCTAssertEqual(29, d!.time.second)
+		XCTAssertTrue(3600 == d!.timeZone.secondsFromGMT())
+		
+		d = Instant(string: "2015-03-28T02:33:29-05:00")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date.year)
+		XCTAssertEqual(Int8(3), d!.date.month!)
+		XCTAssertEqual(Int8(28), d!.date.day!)
+		XCTAssertEqual(Int8(2), d!.time.hour)
+		XCTAssertEqual(Int8(33), d!.time.minute)
+		XCTAssertEqual(29, d!.time.second)
+		XCTAssertTrue(-18000 == d!.timeZone.secondsFromGMT())
+		
+		d = Instant(string: "2015-03-28T02:33:29.1285-05:00")
+		XCTAssertFalse(nil == d)
+		XCTAssertEqual(2015, d!.date.year)
+		XCTAssertEqual(Int8(3), d!.date.month!)
+		XCTAssertEqual(Int8(28), d!.date.day!)
+		XCTAssertEqual(Int8(2), d!.time.hour)
+		XCTAssertEqual(Int8(33), d!.time.minute)
+		XCTAssertEqual(29.1285, d!.time.second)
+		XCTAssertTrue(-18000 == d!.timeZone.secondsFromGMT())
+	}
+	
+	func testComparisons() {
+		var a = Instant(string: "2015-03-28T03:11:04Z")!
+		var b = Instant(string: "1915-03-28T03:11:04Z")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = Instant(string: "2015-03-28T03:11:04Z")!
+		b = Instant(string: "2015-03-28T03:11:04+00:00")!
+		XCTAssertFalse(a > b)
+		XCTAssertTrue(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = Instant(string: "2015-03-28T03:11:44+00:00")!
+		b = Instant(string: "2015-03-28T03:17:44+01:00")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = Instant(string: "2015-03-27T22:12:44-05:00")!
+		b = Instant(string: "2015-03-28T03:11:44-00:00")!
+		XCTAssertTrue(a > b)
+		XCTAssertFalse(a == b)
+		XCTAssertTrue(a == a)
+		
+		a = Instant(string: "2015-03-28T05:11:44.3+01:00")!
+		b = Instant(string: "2015-03-27T23:11:44.3-05:00")!
+		XCTAssertFalse(a > b)
+		XCTAssertTrue(a == b)
+		XCTAssertTrue(a == a)
+	}
+	
+	func testConversion() {
+		let inst = Instant(string: "1981-03-28T15:42:03-0500")!
+		let ns = inst.nsDate
+        XCTAssertTrue(inst == ns.fhir_asInstant(), "Conversion to NSDate and back again must not alter `Instant`")		
+	}
+	
+	func testHttpDateParsing() {
+		if let instant = Instant.fromHttpDate("Fri, 14 Aug 2009 14:45:31 GMT") {
+			XCTAssertEqual(instant.date.year, 2009)
+			XCTAssertEqual(instant.date.month, 8)
+			XCTAssertEqual(instant.time.hour, 14)
+			XCTAssertEqual(instant.time.minute, 45)
+		}
+		else {
+			XCTAssertTrue(false, "Failed to parse perfectly fine HTTP date")
+		}
+		
+		if let instant = Instant.fromHttpDate("Sun, 06 Nov 1994 08:49:37 GMT") {
+			XCTAssertEqual(instant.date.year, 1994)
+			XCTAssertEqual(instant.date.month, 11)
+			XCTAssertEqual(instant.time.hour, 8)
+			XCTAssertEqual(instant.time.minute, 49)
+			XCTAssertEqual(instant.time.second, 37.0)
+		}
+		else {
+			XCTAssertTrue(false, "Failed to parse perfectly fine HTTP date")
+		}
+		
+		if let instant = Instant.fromHttpDate("Sunday, 06-Nov-94 08:49:37 GMT") {
+			XCTAssertEqual(instant.date.year, 1994)
+			XCTAssertEqual(instant.date.month, 11)
+			XCTAssertEqual(instant.time.hour, 8)
+			XCTAssertEqual(instant.time.minute, 49)
+			XCTAssertEqual(instant.time.second, 37.0)
+		}
+		else {
+			XCTAssertTrue(false, "Failed to parse perfectly fine HTTP date")
+		}
+		
+		if let instant = Instant.fromHttpDate("Wed Nov 16 08:49:37 1994") {
+			XCTAssertEqual(instant.date.year, 1994)
+			XCTAssertEqual(instant.date.month, 11)
+			XCTAssertEqual(instant.time.hour, 8)
+			XCTAssertEqual(instant.time.minute, 49)
+			XCTAssertEqual(instant.time.second, 37.0)
+		}
+		else {
+			XCTAssertTrue(false, "Failed to parse perfectly fine HTTP date")
+		}
+	}
+}
+

--- a/Swift3Realm/FHIRAbstractBase.swift
+++ b/Swift3Realm/FHIRAbstractBase.swift
@@ -1,0 +1,206 @@
+//
+//  FHIRAbstractBase.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 7/2/14.
+//  2014, SMART Health IT.
+//
+
+import Realm
+import RealmSwift
+/**
+ *  Abstract superclass for all FHIR data elements.
+ */
+open class FHIRAbstractBase: Object {
+	
+	/// The name of the resource or element.
+	open class var resourceType: String {
+		return "FHIRAbstractBase" 
+	}
+	
+	/// The parent/owner of the receiver, if any. Used to dereference resources.
+	weak var _owner: FHIRAbstractBase?
+	
+	/// Resolved references.
+	var _resolved: [String: Resource]?
+
+    override open static func ignoredProperties() -> [String] {
+        return ["_resolved", "_owner"]
+    }
+    
+	/**
+	The default initializer.
+			
+	Forwards to `populate(from:)` and logs all JSON errors to console, if "DEBUG" is defined and true.
+	*/
+	required public init(json: FHIRJSON?, owner: FHIRAbstractBase? = nil) {
+        super.init()
+		_owner = owner
+		if let errors = populate(from: json) {
+			for error in errors {
+				fhir_warn(error.description)
+			}
+		}
+	}
+	
+	required public init() {
+        super.init()
+    }
+    
+    required public init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
+    
+    required public init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+	
+	// MARK: - JSON Capabilities
+	
+	/**
+	Will populate instance variables - overriding existing ones - with values found in the supplied JSON.
+	
+	- parameter json: The JSON dictionary to pull data from
+	- returns:        An optional array of errors reporting missing (when nonoptional) and superfluous properties and properties of the
+	                  wrong type
+	*/
+	public final func populate(from json: FHIRJSON?) -> [FHIRJSONError]? {
+		var present = Set<String>()
+		present.insert("fhir_comments")
+		var errors = populate(from: json, presentKeys: &present) ?? [FHIRJSONError]()
+		
+		// superfluous JSON entries? Ignore "fhir_comments" and "_xy".
+		let superfluous = json?.keys.filter() { !present.contains($0) }
+		if let supflu = superfluous, !supflu.isEmpty {
+			for sup in supflu {
+				if let first = sup.characters.first, "_" != first {
+					errors.append(FHIRJSONError(key: sup, has: type(of: json![sup]!)))
+				}
+			}
+		}
+		return errors.isEmpty ? nil : errors
+	}
+	
+	/**
+	The main function to perform the actual JSON parsing, to be overridden by subclasses.
+	 
+	- parameter json:        The JSON element to use to populate the receiver
+	- parameter presentKeys: An in-out parameter being filled with key names used.
+	- returns:               An optional array of errors reporting missing mandatory keys or keys containing values of the wrong type
+	*/
+	open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
+		return nil
+	}
+	
+	/**
+	Represent the receiver in FHIRJSON, ready to be used for JSON serialization.
+	
+	- returns: The FHIRJSON reperesentation of the receiver
+	*/
+	open func asJSON() -> FHIRJSON {
+		return FHIRJSON()
+	}
+	
+	/**
+	Calls `asJSON()` on all elements in the array and returns the resulting array full of FHIRJSON dictionaries.
+	
+	- parameter array: The array of elements to map to FHIRJSON
+	- returns:         An array of FHIRJSON elements representing the given resources
+	*/
+	open class func asJSONArray(_ array: [FHIRAbstractBase]) -> [FHIRJSON] {
+		return array.map() { $0.asJSON() }
+	}
+	
+	
+	// MARK: - Factories
+	
+	/**
+	Tries to find `resourceType` by inspecting the JSON dictionary, then instantiates the appropriate class for the
+	specified resource type, or instantiates the receiver's class otherwise.
+	
+	- parameter json:  A FHIRJSON decoded from a JSON response
+	- parameter owner: The FHIRAbstractBase owning the new instance, if appropriate
+	- returns:         If possible the appropriate FHIRAbstractBase subclass, instantiated from the given JSON dictionary, Self otherwise
+	*/
+	public final class func instantiate(from json: FHIRJSON?, owner: FHIRAbstractBase?) -> FHIRAbstractBase {
+		if let type = json?["resourceType"] as? String {
+			return factory(type, json: json!, owner: owner)
+		}
+		let instance = self.init(json: json)		// must use 'required' init with dynamic type
+		instance._owner = owner
+		return instance
+	}
+	
+	/**
+	Instantiates an array of the receiver's type and returns it.
+	
+	- parameter fromArray: The FHIRJSON array to instantiate from
+	- parameter owner:     The FHIRAbstractBase owning the new instance, if appropriate
+	- returns:             An array of the appropriate FHIRAbstractBase subclass, if possible, Self otherwise
+	*/
+	public final class func instantiate(fromArray: [FHIRJSON], owner: FHIRAbstractBase? = nil) -> [FHIRAbstractBase] {
+		return fromArray.map() { instantiate(from: $0, owner: owner) }
+	}
+	
+	
+	// MARK: - Resolving References
+	
+	/** Returns the resolved reference with the given id, if it has been resolved already. */
+	open func resolvedReference(_ refid: String) -> Resource? {
+		if let resolved = _resolved?[refid] {
+			return resolved
+		}
+		return _owner?.resolvedReference(refid)
+	}
+	
+	/**
+	Stores the resolved reference into the `_resolved` dictionary.
+	
+	This method is public because it's used in an extension in our client. You likely don't need to use it explicitly, use the
+	`resolve(type:callback:)` method on `Reference` instead.
+	
+	- parameter refid: The reference identifier as String
+	- parameter resolved: The resource that was resolved
+	*/
+	open func didResolveReference(_ refid: String, resolved: Resource) {
+		if nil != _resolved {
+			_resolved![refid] = resolved
+		}
+		else {
+			_resolved = [refid: resolved]
+		}
+	}
+	
+	/**
+	The resource owning the receiver; used during reference resolving and to look up the instance's `_server`, if any.
+	
+	- returns: The owning `DomainResource` instance or nil
+	*/
+	open var owningResource: DomainResource? {
+		var owner = _owner
+		while nil != owner {
+			if let owner = owner as? DomainResource {
+				return owner
+			}
+			owner = owner?._owner
+		}
+		return nil
+	}
+	
+	/**
+	Returns the receiver's owning Bundle, if it has one.
+	
+	- returns: The owning `Bundle` instance or nil
+	*/
+	open var owningBundle: Bundle? {
+		var owner = _owner
+		while nil != owner {
+			if let owner = owner as? Bundle {
+				return owner
+			}
+			owner = owner?._owner
+		}
+		return nil
+	}
+}
+

--- a/Swift3Realm/FHIRAbstractResource.swift
+++ b/Swift3Realm/FHIRAbstractResource.swift
@@ -1,0 +1,60 @@
+//
+//  FHIRAbstractResource.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 7/2/14.
+//  2014, SMART Health IT.
+//
+
+import Foundation
+
+
+/**
+ *  Abstract superclass for all FHIR resource models.
+ */
+open class FHIRAbstractResource: FHIRAbstractBase {
+	
+	/// A specific version id, if the instance was created using `vread`.
+	open var _versionId: String?
+	
+	/// If this instance lives on a server, this property represents that server.
+	open var _server: FHIRServer? {
+		get { return __server ?? owningResource?._server }
+		set { __server = newValue }
+	}
+	var __server: FHIRServer?
+	
+	/**
+	The Resource, in contrast to the base element, definitely wants "resourceType" to be present. Will return an error complaining about it
+	missing if it's not present.
+	*/
+	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
+		guard let json = json else {
+			return nil
+		}
+		if let type = json["resourceType"] as? String {
+			presentKeys.insert("resourceType")
+			if type != type(of: self).resourceType {
+				return [FHIRJSONError.init(key: "resourceType", problem: "should be “\(type(of: self).resourceType)” but is “\(type)”")]
+			}
+			return super.populate(from: json, presentKeys: &presentKeys)
+		}
+		return [FHIRJSONError(key: "resourceType")]
+	}
+	
+	/** Serialize the receiver to JSON. */
+	open override func asJSON() -> FHIRJSON {
+		var json = super.asJSON()
+		json["resourceType"] = type(of: self).resourceType
+		
+		return json
+	}
+	
+	
+	// MARK: - Printable
+	
+	override open var description: String {
+		return "<\(type(of: self).resourceType)> \(__server?.baseURL.absoluteString ?? "nil")"
+	}
+}
+

--- a/Swift3Realm/FHIRError.swift
+++ b/Swift3Realm/FHIRError.swift
@@ -1,0 +1,170 @@
+//
+//  FHIRError.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 11/24/15.
+//  2015, SMART Health IT.
+//
+
+import Foundation
+
+
+/**
+FHIR errors.
+*/
+public enum FHIRError: Error, CustomStringConvertible {
+	case error(String)
+	
+	case resourceLocationUnknown
+	case resourceWithoutServer
+	case resourceWithoutId
+	case resourceAlreadyHasId
+	case resourceFailedToInstantiate(String)
+	case resourceCannotContainItself
+	
+	case requestCannotPrepareBody
+	case requestNotSent(String)
+	case requestError(Int, String)
+	case noRequestHandlerAvailable(String)
+	case noResponseReceived
+	case responseLocationHeaderResourceTypeMismatch(String, String)
+	case responseNoResourceReceived
+	
+	/// The resource type received (1st String) does not match the expected type (2nd String).
+	case responseResourceTypeMismatch(String, String)
+	
+	case operationConfigurationError(String)
+	case operationInputParameterMissing(String)
+	case operationNotSupported(String)
+	
+	case searchResourceTypeNotDefined
+	
+	/// JSON parsing failed for reason in 1st argument, full JSON string is 2nd argument.
+	case jsonParsingError(String, String)
+	
+	public var description: String {
+		switch self {
+		case .error(let message):
+			return message
+		
+		case .resourceLocationUnknown:
+			return "The location of the resource is not known".fhir_localized
+		case .resourceWithoutServer:
+			return "The resource does not have a server instance assigned".fhir_localized
+		case .resourceWithoutId:
+			return "The resource does not have an id, cannot proceed".fhir_localized
+		case .resourceAlreadyHasId:
+			return "The resource already have an id, cannot proceed".fhir_localized
+		case .resourceFailedToInstantiate(let path):
+			return "\("Failed to instantiate resource when trying to read from".fhir_localized): «\(path)»"
+		case .resourceCannotContainItself:
+			return "A resource cannot contain itself".fhir_localized
+		
+		case .requestCannotPrepareBody:
+			return "`FHIRServerRequestHandler` cannot prepare request body data".fhir_localized
+		case .requestNotSent(let reason):
+			return "\("Request not sent".fhir_localized): \(reason)"
+		case .requestError(let status, let message):
+			return "\("Error".fhir_localized) \(status): \(message)"
+		case .noRequestHandlerAvailable(let type):
+			return "\("No request handler is available for requests of type".fhir_localized) “\(type)”"
+		case .noResponseReceived:
+			return "No response received".fhir_localized
+		case .responseLocationHeaderResourceTypeMismatch(let location, let expectedType):
+			return "\("“Location” header resource type mismatch. Expecting".fhir_localized) “\(expectedType)” \("in".fhir_localized) “\(location)”"
+		case .responseNoResourceReceived:
+			return "No resource data was received with the response".fhir_localized
+		case .responseResourceTypeMismatch(let receivedType, let expectedType):
+			return "Returned resource is of wrong type, expected “\(expectedType)” but received “\(receivedType)”"
+		
+		case .operationConfigurationError(let message):
+			return message
+		case .operationInputParameterMissing(let name):
+			return "\("Operation is missing input parameter".fhir_localized): “\(name)”"
+		case .operationNotSupported(let name):
+			return "\("Operation is not supported".fhir_localized): \(name)"
+			
+		case .searchResourceTypeNotDefined:
+			return "Cannot find the resource type against which to run the search".fhir_localized
+		
+		case .jsonParsingError(let reason, let raw):
+			return "\("Failed to parse JSON".fhir_localized): \(reason)\n\(raw)"
+		}
+	}
+}
+
+
+/**
+Errors thrown during JSON parsing.
+*/
+public struct FHIRJSONError: Error, CustomStringConvertible {
+	
+	/// The error type.
+	public var code: FHIRJSONErrorType
+	
+	/// The JSON property key generating the error.
+	public var key: String
+	
+	/// The type expected for values of this key.
+	public var wants: Any.Type?
+	
+	/// The type received for this key.
+	public var has: Any.Type?
+	
+	/// A problem description.
+	public var problem: String?
+	
+	
+	/** Designated initializer. */
+	init(code: FHIRJSONErrorType, key: String) {
+		self.code = code
+		self.key = key
+	}
+	
+	/** Initializer to use when a given JSON key is missing. */
+	public init(key: String) {
+		self.init(code: .missingKey, key: key)
+	}
+	
+	/** Initializer to use when a given JSON key is present but is not expected. */
+	public init(key: String, has: Any.Type) {
+		self.init(code: .unknownKey, key: key)
+		self.has = has
+	}
+	
+	/** Initializer to use when there is a problem with a given JSON key (other than the key missing or being unknown). */
+	public init(key: String, problem: String) {
+		self.init(code: .problemWithValueForKey, key: key)
+		self.problem = problem
+	}
+	
+	/** Initializer to use when the given JSON key is of a wrong type. */
+	public init(key: String, wants: Any.Type, has: Any.Type) {
+		self.init(code: .wrongValueTypeForKey, key: key)
+		self.wants = wants
+		self.has = has
+	}
+	
+	public var description: String {
+		let nul = Any.self
+		switch code {
+		case .missingKey:
+			return "Expecting nonoptional JSON property “\(key)” but it is missing"
+		case .unknownKey:
+			return "Superfluous JSON property “\(key)” of type \(has ?? nul), ignoring"
+		case .wrongValueTypeForKey:
+			return "Expecting JSON property “\(key)” to be `\(wants ?? nul)`, but is \(has ?? nul)"
+		case .problemWithValueForKey:
+			return "Problem with JSON property “\(key)”: \(problem ?? "(problem not described)")"
+		}
+	}
+}
+
+
+public enum FHIRJSONErrorType: Int {
+	case missingKey
+	case unknownKey
+	case wrongValueTypeForKey
+	case problemWithValueForKey
+}
+

--- a/Swift3Realm/FHIRServer.swift
+++ b/Swift3Realm/FHIRServer.swift
@@ -1,0 +1,123 @@
+//
+//  FHIRServer.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 01/24/15.
+//  2015, SMART Health IT.
+//
+
+import Foundation
+
+
+/**
+Struct to describe REST request types, with a convenience method to make a request FHIR compliant.
+*/
+public enum FHIRRequestMethod: String {
+	case GET = "GET"
+	case PUT = "PUT"
+	case POST = "POST"
+	case PATCH = "PATCH"
+	case DELETE = "DELETE"
+	case OPTIONS = "OPTIONS"
+	
+	/**
+	Prepare a given mutable URL request with the respective method and body values.
+	*/
+	public func prepare(request: inout URLRequest, body: Data? = nil) {
+		request.httpMethod = rawValue
+		
+		switch self {
+		case .GET:
+			break
+		case .PUT:
+			request.httpBody = body
+		case .POST:
+			request.httpBody = body
+		case .PATCH:
+			request.httpBody = body
+		case .DELETE:
+			break
+		case .OPTIONS:
+			break
+		}
+	}
+}
+
+
+/**
+Struct to hold request headers. By default, the "Accept-Charset" header is set to "utf-8" upon initialization.
+*/
+public struct FHIRRequestHeaders {
+	
+	/// All the headers the instance is holding on to.
+	public var headers: [FHIRRequestHeaderField: String]
+	
+	public init(_ headers: [FHIRRequestHeaderField: String]? = nil) {
+		var hdrs = [FHIRRequestHeaderField.acceptCharset: "utf-8"]
+		headers?.forEach() { hdrs[$0] = $1 }
+		self.headers = hdrs
+	}
+	
+	public subscript(key: FHIRRequestHeaderField) -> String? {
+		get { return headers[key] }
+		set { headers[key] = newValue }
+	}
+	
+	
+	/**
+	Prepare a given mutable URL request with the receiver's values.
+	*/
+	public func prepare(request: inout URLRequest) {
+		headers.forEach {
+			request.setValue($1, forHTTPHeaderField: $0.rawValue)
+		}
+	}
+}
+
+
+/**
+Describe valid (and supported) FHIR request headers.
+
+The "Authorization" header is not used in the basic library, it is provided for convenience's sake.
+*/
+public enum FHIRRequestHeaderField: String {
+	case accept          = "Accept"
+	case acceptCharset   = "Accept-Charset"
+	case authorization   = "Authorization"
+	case contentType     = "Content-Type"
+	case prefer          = "Prefer"
+	case ifMatch         = "If-Match"
+	case ifNoneMatch     = "If-None-Match"
+	case ifModifiedSince = "If-Modified-Since"
+	case ifNoneExist     = "If-None-Exist"
+}
+
+
+/**
+Protocol for server objects to be used by `FHIRResource` and subclasses.
+*/
+public protocol FHIRServer {
+	
+	/** A server object must always have a base URL. */
+	var baseURL: URL { get }
+	
+	/**
+	Designated initializer. Should make sure that the base URL ends with a "/"!
+	*/
+	init(baseURL base: URL, auth: [String: Any]?)
+	
+	
+	// MARK: - HTTP Request
+	
+	/*
+	Execute a request of given type against the given path, which is relative to the receiver's `baseURL`, with the given resource (if any).
+	
+	- parameter ofType:            The HTTP method type of the request
+	- parameter path:              The relative path on the server to be interacting against
+	- parameter resource:          The resource to be involved in the request, if any
+	- parameter additonalHeaders:  The headers to set on the request
+	- parameter callback:          A callback, likely called asynchronously, returning a response instance
+	*/
+	func performRequest(ofType: FHIRRequestMethod, path: String, resource: Resource?, additionalHeaders: FHIRRequestHeaders?, callback: @escaping ((FHIRServerResponse) -> Void))
+}
+

--- a/Swift3Realm/FHIRServerResponse.swift
+++ b/Swift3Realm/FHIRServerResponse.swift
@@ -1,0 +1,82 @@
+//
+//  FHIRServerResponse.swift
+//  SwiftSMART
+//
+//  Created by Pascal Pfiffner on 3/31/15.
+//  2015, SMART Platforms.
+//
+
+import Foundation
+
+
+/**
+Encapsulates a server response, which can also indicate that there was no response or not even a request, in which case the `error`
+property carries the only useful information.
+*/
+public protocol FHIRServerResponse {
+	
+	/// The HTTP status code.
+	var status: Int { get }
+	
+	/// Response headers.
+	var headers: [String: String] { get }
+	
+	/// The response body data.
+	var body: Data? { get }
+	
+	/// The request's operation outcome, if any.
+	var outcome: OperationOutcome? { get }
+	
+	/// The error encountered, if any.
+	var error: FHIRError? { get }
+	
+	
+	/**
+	Instantiate a FHIRServerResponse from an URLResponse, Data and an Error.
+	*/
+	init(response: URLResponse, data: Data?, error: Error?)
+	
+	/**
+	Instantiate a response that only represents an error, possibly because it wasn't even sent.
+	*/
+	init(error: Error)
+	
+	
+	// MARK: - Responses
+	
+	/**
+	Extract the resource of the given type from the response, if possible.
+	
+	- parameter ofType: The type of resource to extract
+	- returns:          The resource that was found in the response if it is of the desired type, nil otherwise
+	*/
+	func responseResource<T: Resource>(ofType: T.Type) -> T?
+	
+	/**
+	The response should inspect response headers and update resource data like `id` and `meta` accordingly.
+	
+	This method must not be called if the response has a non-nil error.
+	
+	- throws:       The method should only throw on severe cases, like if Location headers were returned that don't match the resource type
+	- parameter to: The resource to apply response data to
+	*/
+	func applyHeaders(to: Resource) throws
+	
+	/**
+	The response should apply response body data to the given resource. It should throw `FHIRError.ResponseNoResourceReceived` if there was
+	no response data.
+	
+	This method must not be called if the response has a non-nil error.
+	
+	- throws:       The method should throw if resource data was returned that doesn't match the given resource's type, but also if there
+	                was no response data at all (`FHIRError.ResponseNoResourceReceived` in that case)
+	- parameter to: The resource to apply response data to
+	*/
+	func applyBody(to: Resource) throws
+	
+	/**
+	Represent a response that was not received.
+	*/
+	static func noneReceived() -> Self
+}
+

--- a/Swift3Realm/FHIRTypes.swift
+++ b/Swift3Realm/FHIRTypes.swift
@@ -1,0 +1,124 @@
+//
+//  FHIRTypes.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 12/16/14.
+//  2014, SMART Health IT.
+//
+
+import Foundation
+import RealmSwift
+
+/**
+A JSON dictionary, with `String` keys and `AnyObject` values.
+*/
+public typealias FHIRJSON = [String: Any]
+
+
+/**
+Data encoded as a base-64 string.
+*/
+final public class Base64Binary: Object, ExpressibleByStringLiteral, Comparable {
+	public typealias UnicodeScalarLiteralType = Character
+	public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+	
+	public dynamic var value: String?
+	
+	public convenience init(val: String) {
+        self.init()
+		self.value = val
+	}
+	
+    public convenience init(string val: String) {
+        self.init()
+        self.value = val
+    }
+    
+	// MARK: - ExpressibleByStringLiteral
+	
+	public convenience init(stringLiteral value: StringLiteralType) {
+        self.init()
+		self.value = value
+	}
+	
+	public convenience init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+        self.init()
+		self.value = "\(value)"
+	}
+	
+	public convenience init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+        self.init()
+		self.value = value
+	}
+	
+	
+	// MARK: - Printable, Equatable and Comparable
+	
+	override public var description: String {
+		return "<Base64Binary; \(nil != value ? value!.characters.count : 0) chars>"
+	}
+	
+	public static func <(lh: Base64Binary, rh: Base64Binary) -> Bool {
+		guard let lhs = lh.value else {
+			return true
+		}
+		guard let rhs = rh.value else {
+			return false
+		}
+		return lhs < rhs
+	}
+	
+	public static func ==(lhs: Base64Binary, rhs: Base64Binary) -> Bool {
+		return lhs.value == rhs.value
+	}
+    
+    public static func ==(lhs: Base64Binary?, rhs: Base64Binary) -> Bool {
+        if let lhs = lhs {
+            return lhs == rhs
+        }
+        
+        return false
+    }
+    
+    public static func ==(lhs: Base64Binary, rhs: Base64Binary?) -> Bool {
+        if let rhs = rhs {
+            return lhs == rhs
+        }
+        
+        return false
+    }
+}
+
+// MARK: - Helper Functions
+
+extension String {
+	/**
+	Convenience getter using `NSLocalizedString()` with no comment.
+	
+	TODO: On Linux this currently simply returns self
+	*/
+	public var fhir_localized: String {
+		#if os(Linux)
+		return self
+		#else
+		return NSLocalizedString(self, comment: "")
+		#endif
+	}
+}
+
+/**
+Execute a `print()`, prepending filename, line and function/method name, if `DEBUG` is defined.
+*/
+public func fhir_logIfDebug(_ message: @autoclosure () -> String, function: String = #function, file: String = #file, line: Int = #line) {
+#if DEBUG
+	print("SwiftFHIR [\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(function)  \(message())")
+#endif
+}
+
+/**
+Execute a `print()`, prepending filename, line and function/method name and "WARNING" prepended.
+*/
+public func fhir_warn(_ message: @autoclosure () -> String, function: String = #function, file: String = #file, line: Int = #line) {
+	print("SwiftFHIR [\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(function)  WARNING: \(message())")
+}
+

--- a/Swift3Realm/JSON-extensions.swift
+++ b/Swift3Realm/JSON-extensions.swift
@@ -1,0 +1,150 @@
+//
+//  JSON-extensions.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 7/4/14.
+//  2014, SMART Health IT.
+//
+
+import Foundation
+
+
+extension String {
+	public func asJSON() -> String {
+		return self
+	}
+}
+
+extension Bool {
+	public func asJSON() -> Bool {
+		return self
+	}
+}
+
+extension Int {
+	public func asJSON() -> Int {
+		return self
+	}
+}
+
+extension UInt {
+	public func asJSON() -> UInt {
+		return self
+	}
+}
+
+extension URL {
+	
+	public init?(json: String) {
+		self.init(string: json)
+	}
+	
+	public static func instantiate(fromArray json: [String]) -> [URL] {
+		var arr: [URL] = []
+		for string in json {
+			if let url = URL(string: string) {
+				arr.append(url)
+			}
+		}
+		return arr
+	}
+	
+	public func asJSON() -> String {
+		return self.description
+	}
+}
+
+extension RealmDecimal {
+	/*
+		Takes an NSNumber, usually decoded from JSON, and creates an Decimal instance
+	
+		We're using a string format approach using "%.15g" since NSJSONFormatting returns NSNumber objects instantiated
+		with Double() or Int(). In the former case this causes precision issues (e.g. try 8.7). Unfortunately, some
+		doubles with 16 and 17 significant digits will be truncated (e.g. a longitude of "4.844614000123024").
+	
+		TODO: improve to avoid double precision issues
+	 */
+	public convenience init(json: NSNumber) {
+		if let _ = json.stringValue.characters.index(of: ".") {
+			self.init(string: String(format: "%.15g", json.doubleValue))
+		}
+		else {
+			self.init(string: "\(json)")
+		}
+	}
+	
+	public func asJSON() -> Decimal {
+		return self.value
+	}
+}
+
+extension Base64Binary {
+	public func asJSON() -> String {
+		return self.value ?? ""
+	}
+}
+
+extension FHIRDate {
+	public static func instantiate(fromArray json: [String]) -> [FHIRDate] {
+		var arr: [FHIRDate] = []
+		for string in json {
+			if let obj = FHIRDate(string: string) {
+				arr.append(obj)
+			}
+		}
+		return arr
+	}
+	
+	public func asJSON() -> String {
+		return self.description
+	}
+}
+
+extension FHIRTime {
+	public static func instantiate(fromArray json: [String]) -> [FHIRTime] {
+		var arr: [FHIRTime] = []
+		for string in json {
+			if let obj = FHIRTime(string: string) {
+				arr.append(obj)
+			}
+		}
+		return arr
+	}
+	
+	public func asJSON() -> String {
+		return self.description
+	}
+}
+
+extension DateTime {
+	public static func instantiate(fromArray json: [String]) -> [DateTime] {
+		var arr: [DateTime] = []
+		for string in json {
+			if let obj = DateTime(string: string) {
+				arr.append(obj)
+			}
+		}
+		return arr
+	}
+	
+	public func asJSON() -> String {
+		return self.description
+	}
+}
+
+extension Instant {
+	public static func instantiate(fromArray json: [String]) -> [Instant] {
+		var arr: [Instant] = []
+		for string in json {
+			if let obj = Instant(string: string) {
+				arr.append(obj)
+			}
+		}
+		return arr
+	}
+	
+	public func asJSON() -> String {
+		return self.description
+	}
+}
+

--- a/Swift3Realm/RealmTestingProtocols.swift
+++ b/Swift3Realm/RealmTestingProtocols.swift
@@ -1,0 +1,42 @@
+//
+//  File.swift
+//  realm-swift-fhir
+//
+//  Created by Ryan Baldwin on 2017-01-25.
+//
+
+import XCTest
+import RealmSwift
+
+/// Provides a small set of functionality to assist in Unit Testing something which depends on an in-memory Realm.
+protocol RealmPersistenceTesting: class {}
+
+extension RealmPersistenceTesting where Self: XCTestCase {
+    /// Clears the current in-memory realm of all entities.
+    func clear(realm: Realm) {
+        try! realm.write {
+            realm.deleteAll()
+        }
+    }
+    
+    /// Creates a new Realm based on the current configuration
+    ///
+    /// - Returns: A new Realm instance
+    func makeRealm() -> Realm {
+        var realm: Realm!
+        stopwatch(label: "Time to fire up realm") {
+            realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "RealmSwiftFHIRInMemDB"))
+        }
+        
+        clear(realm: realm)
+        return realm
+    }
+
+    func stopwatch(label: String, _ closure: () -> ()) {
+        let start = Date()
+        closure()
+        let end = Date()
+        let timeInterval: Double = end.timeIntervalSince(start)
+        print("\(label): \(timeInterval)")
+    }
+}

--- a/Swift3Realm/RealmTypes.swift
+++ b/Swift3Realm/RealmTypes.swift
@@ -1,0 +1,146 @@
+//
+//  RealmTypes.swift
+//  SwiftFHIR
+//
+//  Created by Ryan Baldwin on 01/21/17
+//  2017, Ryan Baldwin
+//
+
+import Foundation
+import RealmSwift
+
+public class RealmString: Object {
+    public dynamic var value: String = ""
+
+    public convenience init(val: String) {
+        self.init()
+        self.value = val
+    }
+}
+
+public class RealmInt: Object {
+    public dynamic var value: Int = 0
+
+    public convenience init(val: Int) {
+        self.init()
+        self.value = val
+    }
+}
+
+public class RealmDecimal: Object {
+    private dynamic var _value = "0"
+
+    public var value: Decimal {
+        get { return Decimal(string: _value)! }
+        set { _value = String(describing: newValue) }
+    }
+
+    public convenience init(string val: String) {
+        self.init()
+        self._value = val
+    }
+
+    public override class func ignoredProperties() -> [String] {
+        return ["value"]
+    }
+
+    public static func ==(lhs: RealmDecimal, rhs: RealmDecimal) -> Bool {
+        return lhs.value.isEqual(to: rhs.value)
+    }
+    
+    public static func ==(lhs: RealmDecimal?, rhs: RealmDecimal) -> Bool {
+        if let lhs = lhs {
+            return lhs == rhs
+        }
+        
+        return false
+    }
+    
+    public static func ==(lhs: RealmDecimal, rhs: RealmDecimal?) -> Bool {
+        if let rhs = rhs {
+            return lhs == rhs
+        }
+        
+        return false
+    }    
+}
+
+public class RealmURL: Object {
+    private dynamic var _value: String?
+    
+    private var _url: URL? = nil
+    public var value: URL? {
+        get {
+            if _url == nil {
+                _url = URL(string: _value ?? "")
+            }
+            
+            return _url
+        }
+        set {
+            _url = newValue
+            _value = newValue?.absoluteString ?? ""
+        }
+    }
+    
+    public override class func ignoredProperties() -> [String] {
+        return ["value", "_url"]
+    }
+}
+
+/// Realm is limited in its polymorphism and can't contain a List of different
+/// classes. As a result, for example, deserializing from JSON into a DomainResource
+/// will fail if that resource has any contained resources.
+///
+/// In normal SwiftFHIR the `DomainResource.contained` works fine, but because of 
+/// Swift's limitations it fails. `DomainResource.contained: RealmSwift<Resource>` 
+/// will blow up at runtime. The workaround is to create a `ContainedResource: Resource`
+/// Which will store the same information as `Resource`, but will also provide functionality
+/// to store the original JSON and inflate it on demand into the proper type.
+public class ContainedResource: Resource {
+    public dynamic var resourceType: String?
+    
+    private dynamic var json: Data?
+    
+    private var _resource: FHIRAbstractBase? = nil
+    public var resource: FHIRAbstractBase? {
+        guard let resourceType = resourceType,
+              let json = json else {
+            return nil
+        }
+        
+        if _resource == nil {
+            let js = NSKeyedUnarchiver.unarchiveObject(with: json) as! FHIRJSON
+            _resource = FHIRAbstractBase.factory(resourceType, json: js, owner: nil)
+        }
+        
+        return _resource
+    }
+    
+    public override func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
+        var errors = super.populate(from: json, presentKeys: &presentKeys) ?? [FHIRJSONError]()        
+        if let js = json {
+            if let exist = js["resourceType"] {
+                presentKeys.insert("resourceType")
+                if let val = exist as? String {
+                    self.resourceType = val
+                }
+                else {
+                    errors.append(FHIRJSONError(key: "resourceType", wants: String.self, has: type(of: exist)))
+                }
+            }
+            
+            self.json = NSKeyedArchiver.archivedData(withRootObject: js)
+        }
+        
+        return errors.isEmpty ? nil : errors
+    }
+    
+    public override func asJSON() -> FHIRJSON {
+        guard let resource = resource else {
+            return ["fhir_comments": "Failed to serialize ContainedResource (\(self.resourceType)) because the resource was not set."]
+        }
+        
+        return resource.asJSON()
+    }
+}

--- a/Swift3Realm/XCTestCase+FHIR.swift
+++ b/Swift3Realm/XCTestCase+FHIR.swift
@@ -1,0 +1,37 @@
+//
+//  XCTestCase+FHIR.swift
+//  SwiftFHIR
+//
+//  Created by Pascal Pfiffner on 8/27/14.
+//  2014, SMART Health IT.
+//
+
+import XCTest
+import RealmSwiftFHIR
+
+
+/**
+ *  Extension providing a `readJSONFile(filename:)` method to read JSON files from disk.
+ */
+extension XCTestCase {
+	
+	class var testsDirectory: String {
+		let dir = #file as NSString
+		let proj = ((dir.deletingLastPathComponent as NSString).deletingLastPathComponent as NSString).deletingLastPathComponent as NSString
+		return proj.appendingPathComponent("realm-swift-fhirTests/fhir-parser/downloads")
+	}
+	
+	func readJSONFile(_ filename: String) throws -> FHIRJSON {
+		let dir = type(of: self).testsDirectory
+		XCTAssertTrue(FileManager.default.fileExists(atPath: dir), "You must either first download the FHIR spec or manually adjust `XCTestCase.testsDirectory` to point to your FHIR download directory")
+		
+		let path = (dir as NSString).appendingPathComponent(filename)
+		let data = try Data(contentsOf: URL(fileURLWithPath: path))
+		let json = try JSONSerialization.jsonObject(with: data, options: []) as? FHIRJSON
+		if let json = json {
+			return json
+		}
+		throw FHIRError.error("Unable to decode «\(path)» to JSON")
+	}
+}
+

--- a/Swift3Realm/mappings.py
+++ b/Swift3Realm/mappings.py
@@ -3,25 +3,28 @@
 # Which class names to map to resources and elements
 classmap = {
     'Any': 'Resource',
+    'Protocol': 'ProtocolFHIR',
     
     'boolean': 'Bool',
     'integer': 'Int',
-    'positiveInt': 'UInt',
-    'unsignedInt': 'UInt',
-    'decimal': 'NSDecimalNumber',
+    'positiveInt': 'Int',
+    'unsignedInt': 'Int',
+    'decimal': 'RealmDecimal',
     
     'string': 'String',
     'markdown': 'String',
     'id': 'String',
     'code': 'String',       # for now we're not generating enums for these
-    'uri': 'NSURL',
+    'uri': 'String',
     'oid': 'String',
     'uuid': 'String',
     'xhtml': 'String',
     'base64Binary': 'Base64Binary',
+    'date': 'FHIRDate',
+    'time': 'FHIRTime',
 }
 
-# Classes to be replaced with different ones at resource rendering time
+# Classes of properties to be replaced with different ones at resource rendering time
 replacemap = {}
 
 # Some properties (in Conformance, Profile and Questionnaire currently) can be
@@ -58,13 +61,13 @@ starexpandtypes = {
 }
 
 # Which class names are native to the language (or can be treated this way)
-natives = ['Bool', 'Int', 'UInt', 'String', 'Base64Binary', 'NSNumber', 'NSDecimalNumber', 'Date', 'Time', 'DateTime', 'Instant', 'NSURL']
+natives = ['Bool', 'Int', 'String', 'Base64Binary', 'NSNumber', 'RealmDecimal', 'FHIRDate', 'FHIRTime', 'DateTime', 'Instant', 'RealmURL']
 
 # Which classes are primitives and don't support the RealmSwift.List<> without an Object wrapper
-primitives = []
+primitives = ['Bool', 'Int', 'String', 'NSNumber']
 
 # which class names require to be wrapped in RealmOptional
-realm_optionals = []
+realm_optionals = ['Bool', 'Int', 'NSNumber']
 
 # Which classes are to be expected from JSON decoding
 jsonmap = {
@@ -74,12 +77,12 @@ jsonmap = {
     'Double': 'NSNumber',
     
     'String': 'String',
-    'Date': 'String',
-    'Time': 'String',
+    'FHIRDate': 'String',
+    'FHIRTime': 'String',
     'DateTime': 'String',
     'Instant': 'String',
-    'NSDecimalNumber': 'NSNumber',
-    'NSURL': 'String',
+    'RealmDecimal': 'NSNumber',
+    'RealmURL': 'String',
     'Base64Binary': 'String',
 }
 jsonmap_default = 'FHIRJSON'
@@ -94,4 +97,5 @@ reservedmap = {
     'operator': 'operator_fhir',
     'repeat': 'repeat_fhir',
     'description': 'description_fhir',    # Reserved for `Printable` classes
+    'hash': 'hash_fhir'
 }

--- a/Swift3Realm/settings.py
+++ b/Swift3Realm/settings.py
@@ -1,0 +1,72 @@
+# These are settings for the FHIR class generator
+
+from Swift3Realm.mappings import *
+
+# Base URL for where to load specification data from
+specification_url = 'http://hl7.org/fhir/dstu2/'
+#specification_url = 'http://hl7.org/fhir/2016May/'
+#specification_url = 'http://hl7-fhir.github.io'
+
+# Whether and where to put the generated class models
+write_resources = True
+tpl_resource_target_ptrn = '../Models/{}.swift'             # where to write the generated class files to, with one "{}" placeholder for the class name
+
+# Whether and where to put the factory methods
+write_factory = write_resources        # required in Swift
+tpl_factory_target = '../Models/FHIRAbstractBase+Factory.swift'
+
+# Whether and where to write unit tests
+write_unittests = True
+tpl_unittest_target_ptrn = '../Tests/ModelTests/{}Tests.swift'  # a pattern to determine the output files for unit tests; the one placeholder will be the class name
+
+
+##
+##  Know what you do when changing the following settings
+##
+
+
+# classes/resources
+default_base = {
+    'complex-type': 'FHIRAbstractBase',                 # for "Element"
+    'resource': 'FHIRAbstractResource',                 # for "Resource"
+}
+resource_modules_lowercase = False                      # whether all resource paths (i.e. modules) should be lowercase
+tpl_resource_source = 'Swift3Realm/template-resource.swift'   # the template to use as source when writing resource implementations for profiles
+manual_profiles = [                                     # all these profiles should be copied to dirname(`tpl_resource_target_ptrn`): tuples of (path, module, profile-name-list)
+    ('Swift3Realm/FHIRAbstractBase.swift', None, ['FHIRAbstractBase']),
+    ('Swift3Realm/FHIRAbstractResource.swift', None, ['FHIRAbstractResource']),
+    ('Swift3Realm/FHIRTypes.swift', None, [
+    	'boolean',
+    	'string', 'base64Binary', 'code', 'id',
+    	'decimal', 'integer', 'positiveInt', 'unsignedInt',
+    	'uri', 'oid', 'uuid',
+    ]),
+    ('Swift3Realm/DateAndTime.swift', None, [
+        'date', 'dateTime', 'time', 'instant',
+    ]),
+    ('Swift3Realm/JSON-extensions.swift', None, []),
+    ('Swift3Realm/FHIRServer.swift', None, []),
+    ('Swift3Realm/FHIRServerResponse.swift', None, []),
+    ('Swift3Realm/FHIRError.swift', None, []),
+    ('Swift3Realm/RealmTypes.swift', None, []),
+]
+
+# factory methods
+tpl_factory_source = 'Swift3Realm/template-elementfactory.swift'
+
+# search parameters
+write_searchparams = False
+search_generate_camelcase = True
+tpl_searchparams_source = ''
+tpl_searchparams_target = ''
+
+# unit tests
+tpl_unittest_source = 'Swift3Realm/template-unittest.swift'
+unittest_copyfiles = [
+    'Swift3Realm/XCTestCase+FHIR.swift',
+    'Swift3Realm/DateAndTimeTests.swift',
+    'Swift3Realm/RealmTestingProtocols.swift'
+]
+unittest_format_path_prepare = '{}?'            # used to format `path` before appending another path element - one placeholder for `path`
+unittest_format_path_key = '{}.{}'              # used to create property paths by appending `key` to the existing `path` - two placeholders
+unittest_format_path_index = '{}[{}]'          # used for array properties - two placeholders, `path` and the array index

--- a/Swift3Realm/template-elementfactory.swift
+++ b/Swift3Realm/template-elementfactory.swift
@@ -1,0 +1,26 @@
+//
+//  FHIRAbstractBase+Factory.swift
+//  SwiftFHIR
+//
+//  Generated from FHIR {{ info.version }} on {{ info.date }}.
+//  {{ info.year }}, SMART Health IT.
+//
+
+
+/**
+ *  Extension to FHIRAbstractBase to be able to instantiate by class name.
+ */
+extension FHIRAbstractBase {
+	
+	public class func factory(_ className: String, json: FHIRJSON, owner: FHIRAbstractBase?) -> FHIRAbstractBase {
+		switch className {
+		{%- for klass in classes %}{% if klass.resource_name %}
+			case "{{ klass.resource_name }}":
+				return {{ klass.name }}(json: json, owner: owner)
+		{%- endif %}{% endfor %}
+			default:
+				return FHIRAbstractBase(json: json, owner: owner)
+		}
+	}
+}
+

--- a/Swift3Realm/template-resource.swift
+++ b/Swift3Realm/template-resource.swift
@@ -1,0 +1,148 @@
+//
+//  {{ profile.targetname }}.swift
+//  SwiftFHIR
+//
+//  Generated from FHIR {{ info.version }} ({{ profile.url }}) on {{ info.date }}.
+//  {{ info.year }}, SMART Health IT.
+//
+
+import Foundation
+import RealmSwift
+{% for klass in classes %}
+
+/**
+ *  {{ klass.short|wordwrap(width=116, wrapstring="\n *  ") }}.
+{%- if klass.formal %}
+ *
+ *  {{ klass.formal|wordwrap(width=116, wrapstring="\n *  ") }}
+{%- endif %}
+ */
+open class {{ klass.name }}: {{ klass.superclass.name|default('FHIRAbstractBase') }} {
+{%- if klass.resource_name %}
+	override open class var resourceType: String {
+		get { return "{{ klass.resource_name }}" }
+	}
+{% endif -%}
+	
+{%- for prop in klass.properties %}
+	{% if prop.is_array -%}
+		{%- if prop.is_primitive -%}
+			public let {{ prop.name }} = RealmSwift.List<Realm{{ prop.class_name }}>()
+		{%- elif prop.class_name -%}
+			public let {{ prop.name }} = RealmSwift.List<{% if "Resource" == prop.class_name %}ContainedResource{%else%}{{ prop.class_name }}{%endif%}>()
+		{%- endif -%}
+	{%- else -%}
+		{%- if prop.requires_realm_optional -%}
+			public let {{ prop.name }} = RealmOptional<{{ prop.class_name }}>()		
+		{%- else -%}		
+			public dynamic var {{ prop.name }}: {{ prop.class_name }}?
+		{%- endif %}
+	{%- endif %}
+	{# any resource with an ID requires a pk for Realm primary keys #}
+	{%- if "id" == prop.name -%}
+	public dynamic var pk = UUID().uuidString
+	override open static func primaryKey() -> String? {
+		return "pk"
+	}
+	{%- endif -%}
+{% endfor %}
+
+{% if klass.has_nonoptional %}	
+	/** Convenience initializer, taking all required properties as arguments. */
+	public convenience init(
+	{%- for nonop in klass.properties|rejectattr("nonoptional", "equalto", false) %}
+		{%- if loop.index is greaterthan 1 %}, {% endif -%}
+		{%- if "value" == nonop.name %}val{% else %}{{ nonop.name }}{% endif %}: {% if nonop.is_array %}[{% endif %}{{ nonop.class_name }}{% if nonop.is_array %}]{% endif %}
+	{%- endfor -%}
+	) {
+		self.init(json: nil)
+	{%- for nonop in klass.properties %}{% if nonop.nonoptional %}
+		{%- if nonop.is_array and nonop.is_native %}
+		self.{{ nonop.name }}.append(objectsIn: {{ nonop.name }}.map{ Realm{{ nonop.class_name }}(value: [$0]) })
+		{%- elif nonop.is_array %}
+		self.{{ nonop.name }}.append(objectsIn: {{ nonop.name }})
+		{%- else %}
+		self.{{ nonop.name }}{% if nonop.requires_realm_optional %}.value{% endif %} = {% if "value" == nonop.name %}val{% else %}{{ nonop.name }}{% endif %}
+		{%- endif %}
+	{%- endif %}{% endfor %}
+	}
+{% endif -%}
+{% if klass.properties %}	
+	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
+		var errors = super.populate(from: json, presentKeys: &presentKeys) ?? [FHIRJSONError]()
+		if let js = json {
+		{%- for prop in klass.properties %}
+			if let exist = js["{{ prop.orig_name }}"] {
+				presentKeys.insert("{{ prop.orig_name }}")
+				if let val = exist as? {% if prop.is_array %}[{% endif %}{{ prop.json_class }}{% if prop.is_array %}]{% endif %} {
+					{%- if prop.class_name == prop.json_class %}
+					{%- if prop.is_array and prop.is_native %}
+					self.{{ prop.name }}.append(objectsIn: val.map{ Realm{{prop.class_name}}(value: [$0]) })
+					{%- else %}
+					self.{{ prop.name }}{% if prop.requires_realm_optional %}.value{% endif %} = val
+					{# if we're inflating from a server JSON, we'll want to default the primaryKey to the same value as id #}
+					{%- if prop.name == "id" %}self.pk = val{% endif %}
+					{%- endif %}
+					{%- else %}
+					
+					{%- if prop.is_array %}{% if prop.is_native or 'FHIRElement' == prop.class_name %}
+					self.{{ prop.name }}.append(objectsIn: {{ prop.class_name }}.instantiate(fromArray: val))
+					{%- elif 'Resource' == prop.class_name %}
+					self.{{ prop.name }}.append(objectsIn: val.map({ return ContainedResource(json: $0, owner: self)}))
+					{%- else %}
+					if let vals = {{ prop.class_name }}.instantiate(fromArray: val, owner: self) as? [{{ prop.class_name }}] {
+						self.{{ prop.name }}.append(objectsIn: vals)
+					}					
+					{%- endif %}
+					
+					{%- else %}{% if prop.is_native %}
+					self.{{ prop.name }}{% if prop.requires_realm_optional %}.value{% endif %} = {{ prop.class_name }}({% if "String" == prop.json_class %}string{% else %}json{% endif %}: val)
+					{%- else %}{% if "Resource" == prop.class_name %}
+					self.{{ prop.name }} = Resource.instantiate(from: val, owner: self) as? Resource
+					{%- else %}
+					self.{{ prop.name }} = {{ prop.class_name }}(json: val, owner: self)
+					{%- endif %}{% endif %}{% endif %}{% endif %}
+				}
+				else {
+					errors.append(FHIRJSONError(key: "{{ prop.orig_name }}", wants: {% if prop.is_array %}Array<{% endif %}{{ prop.json_class }}{% if prop.is_array %}>{% endif %}.self, has: type(of: exist)))
+				}
+			}
+			{%- if prop.nonoptional and not prop.one_of_many %}
+			else {
+				errors.append(FHIRJSONError(key: "{{ prop.orig_name }}"))
+			}
+			{%- endif %}
+		{%- endfor %}
+		{%- if klass.expanded_nonoptionals %}
+			
+			// check if nonoptional expanded properties are present
+			{%- for exp, props in klass.sorted_nonoptionals %}
+			if {% for prop in props %}nil == self.{{ prop.name }}{% if prop.requires_realm_optional %}.value{% endif %}{% if not loop.last %} && {% endif %}{% endfor %} {
+				errors.append(FHIRJSONError(key: "{{ exp }}*"))
+			}
+			{%- endfor %}
+		{%- endif %}
+		}
+		return errors.isEmpty ? nil : errors
+	}
+	
+	override open func asJSON() -> FHIRJSON {
+		var json = super.asJSON()
+		{% for prop in klass.properties %}
+		{%- if prop.is_array %}
+		if {{ prop.name }}.count > 0 {
+			json["{{ prop.orig_name }}"] = Array({{ prop.name }}.map() { {% if prop.is_primitive %}$0.value{% else %}$0.asJSON(){% endif %} })
+		}		
+		{%- else %}
+		if let {{ prop.name }} = self.{{ prop.name }}{% if prop.requires_realm_optional %}.value{% endif %} {
+			json["{{ prop.orig_name }}"] = {{ prop.name }}.asJSON()
+		}
+		{%- endif -%}
+		{%- endfor %}
+		
+		return json
+	}
+{%- endif %}
+}
+{% endfor %}
+

--- a/Swift3Realm/template-unittest.swift
+++ b/Swift3Realm/template-unittest.swift
@@ -1,0 +1,95 @@
+//
+//  {{ class.name }}Tests.swift
+//  RealmSwiftFHIR
+//
+//  Generated from FHIR {{ info.version }} on {{ info.date }}.
+//  {{ info.year }}, SMART Health IT.
+//
+// Tweaked for RealmSupport by Ryan Baldwin, University Health Network.
+
+import XCTest
+import RealmSwift
+import RealmSwiftFHIR
+
+
+class {{ class.name }}Tests: XCTestCase, RealmPersistenceTesting {    
+	var realm: Realm!
+
+	override func setUp() {
+		realm = makeRealm()
+	}
+
+	func instantiateFrom(filename: String) throws -> RealmSwiftFHIR.{{ class.name }} {
+		return instantiateFrom(json: try readJSONFile(filename))
+	}
+	
+	func instantiateFrom(json: FHIRJSON) -> RealmSwiftFHIR.{{ class.name }} {
+		let instance = RealmSwiftFHIR.{{ class.name }}(json: json)
+		XCTAssertNotNil(instance, "Must have instantiated a test instance")
+		return instance
+	}
+	
+{%- for tcase in tests %}
+	
+	func test{{ class.name }}{{ loop.index }}() {		
+		var instance: RealmSwiftFHIR.{{ class.name }}?
+		do {
+			instance = try run{{ class.name }}{{ loop.index }}()
+			try run{{ class.name }}{{ loop.index }}(instance!.asJSON()) 			
+		}
+		catch {
+			XCTAssertTrue(false, "Must instantiate and test {{ class.name }} successfully, but threw")
+		}
+
+		test{{ class.name}}Realm{{ loop.index}}(instance: instance!)
+	}
+
+	func test{{ class.name}}Realm{{ loop.index }}(instance: RealmSwiftFHIR.{{class.name}}) {
+		try! realm.write {
+                realm.add(instance)
+            }
+        try! run{{ class.name }}{{ loop.index }}(realm.objects(RealmSwiftFHIR.{{ class.name }}.self).first!.asJSON())
+        
+        try! realm.write {
+        	instance.implicitRules = "Rule #1"
+            realm.add(instance, update: true)
+        }
+        XCTAssertEqual(1, realm.objects(RealmSwiftFHIR.{{ class.name }}.self).count)
+        XCTAssertEqual("Rule #1", realm.objects(RealmSwiftFHIR.{{ class.name }}.self).first!.implicitRules)
+        
+        try! realm.write {
+            realm.delete(instance)
+        }
+        XCTAssertEqual(0, realm.objects(RealmSwiftFHIR.Account.self).count)
+	}
+	
+	@discardableResult
+	func run{{ class.name }}{{ loop.index }}(_ json: FHIRJSON? = nil) throws -> RealmSwiftFHIR.{{ class.name }} {
+		let inst = (nil != json) ? instantiateFrom(json: json!) : try instantiateFrom(filename: "{{ tcase.filename }}")
+		{% for onetest in tcase.tests %}
+		{%- if "String" == onetest.klass.name %}
+		XCTAssertEqual(inst.{{ onetest.path }}, "{{ onetest.value|replace('"', '\\"') }}")
+		{%- else %}{% if "RealmDecimal" == onetest.klass.name %}
+		XCTAssertTrue(inst.{{ onetest.path }}! == RealmDecimal(string: "{{ onetest.value }}"))
+		{%- else %}{% if "Int" == onetest.klass.name or "Double" == onetest.klass.name %}
+		XCTAssertEqual(inst.{{ onetest.path }}, {{ onetest.value }})
+		{%- else %}{% if "UInt" == onetest.klass.name %}
+		XCTAssertEqual(inst.{{ onetest.path }}, UInt({{ onetest.value }}))
+		{%- else %}{% if "Bool" == onetest.klass.name %}
+		XCTAssert{% if onetest.value %}True{% else %}False{% endif %}(inst.{{ onetest.path }} ?? {% if onetest.value %}false{% else %}true{% endif %})
+		{%- else %}{% if "FHIRDate" == onetest.klass.name or "FHIRTime" == onetest.klass.name or "DateTime" == onetest.klass.name or "Instant" == onetest.klass.name %}
+		XCTAssertEqual(inst.{{ onetest.path }}{% if not onetest.array_item %}?{% endif %}.description, "{{ onetest.value }}")
+		{%- else %}{% if "URL" == onetest.klass.name %}
+		XCTAssertEqual(inst.{{ onetest.path }}{% if not onetest.array_item %}?{% endif %}.absoluteString, "{{ onetest.value }}")
+		{%- else %}{% if "Base64Binary" == onetest.klass.name %}
+		XCTAssertTrue(inst.{{ onetest.path }}! == Base64Binary(val: "{{ onetest.value }}"))
+		{%- else %}
+		// Don't know how to create unit test for "{{ onetest.path }}", which is a {{ onetest.klass.name }}
+		{%- endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}
+		{%- endfor %}
+		
+		return inst
+	}
+{%- endfor %}
+}
+

--- a/fhirclass.py
+++ b/fhirclass.py
@@ -117,6 +117,8 @@ class FHIRClassProperty(object):
         self.module_name = None             # should only be set if it's an external module (think Python)
         self.json_class = spec.json_class_for_class_name(self.class_name)
         self.is_native = spec.class_name_is_native(self.class_name)
+        self.is_primitive = spec.class_name_is_primitive(self.class_name)
+        self.requires_realm_optional = spec.class_name_requires_realm_optional(self.class_name)
         self.is_array = True if '*' == element.n_max else False
         self.nonoptional = True if element.n_min is not None and 0 != int(element.n_min) else False
         self.reference_to_names = [spec.class_name_for_profile(type_obj.profile)] if type_obj.profile is not None else []

--- a/fhirspec.py
+++ b/fhirspec.py
@@ -159,6 +159,12 @@ class FHIRSpec(object):
     def class_name_is_native(self, class_name):
         return class_name in self.settings.natives
     
+    def class_name_is_primitive(self, class_name):
+        return class_name in self.settings.primitives
+
+    def class_name_requires_realm_optional(self, class_name):
+        return class_name in self.settings.realm_optionals
+
     def safe_property_name(self, prop_name):
         return self.settings.reservedmap.get(prop_name, prop_name)
     


### PR DESCRIPTION
Hey Pascal!

Not sure if you'd be interested about this, but I wanted to extend your SwiftFHIR such that it would natively support Realm "out of the box." This is mostly because I was growing impatient hand-rolling my own Questionnaire models based on the FHIR DSTU2 spec. So I forked your `fhir-parser` project and kinda went to town. [I created a RealmSwiftFHIR project](https://github.com/ryanbaldwin/RealmSwiftFHIR) which has the generated code in case you're curious about checking it out and running the tests and such. I am currently using this in a small iOS app that I'm developing at the University Health Network, and so far it seems to be working just peachy.

Anyways - long story short - I work (and have worked with for several years) with James Agnew, and he suggested I maybe clean up my original fork/branch a bit and re-submit it to you as a PR. If you're interested, well, here it is! If not, no harm no foul.

Cheers!

- ryan.

-- old crappy notes
This is a re-branching and more constructive commit of the original
realm-spike branch, which blew away a huge portion of Pascal’s original
project. Instead of basically re-inventing the wheel I created a 4th
set of generator functionality, Swift3Realm, which can be merged into
Pascal’s original project.