### PR TITLE
Fixes for recent fhir changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,3 @@ env
 
 # ignore downloads
 /downloads
-
-.DS_Store
-.project
-.pydevproject
-.settings/org.eclipse.core.resources.prefs

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ env
 # ignore downloads
 /downloads
 
+.DS_Store
+.project
+.pydevproject
+.settings/org.eclipse.core.resources.prefs

--- a/Default/mappings.py
+++ b/Default/mappings.py
@@ -22,6 +22,8 @@ classmap = {
     'id': 'str',
     'code': 'str',      # for now we're not generating enums for these
     'uri': 'str',
+    'url': 'str',
+    'canonical': 'str',
     'oid': 'str',
     'uuid': 'str',
     'xhtml': 'str',

--- a/Default/settings.py
+++ b/Default/settings.py
@@ -7,7 +7,7 @@ from Default.mappings import *
 
 
 # Base URL for where to load specification data from
-specification_url = 'http://hl7.org/fhir/2017Jan/'
+specification_url = 'http://hl7.org/fhir/2018Jan/'
 #specification_url = 'http://build.fhir.org'
 
 # In which directory to find the templates. See below for settings that start with `tpl_`: these are the template names.

--- a/Default/settings.py
+++ b/Default/settings.py
@@ -7,7 +7,7 @@ from Default.mappings import *
 
 
 # Base URL for where to load specification data from
-specification_url = 'http://hl7.org/fhir/2018Jan/'
+specification_url = 'http://hl7.org/fhir/2018May/'
 #specification_url = 'http://build.fhir.org'
 
 # In which directory to find the templates. See below for settings that start with `tpl_`: these are the template names.

--- a/fhirspec.py
+++ b/fhirspec.py
@@ -363,7 +363,6 @@ class FHIRCodeSystem(object):
             logger.debug("Will not generate enum for CodeSystem \"{}\" whose content is {}"
                 .format(self.url, resource['content']))
             return
-
         assert concepts, "Expecting at least one code for \"complete\" CodeSystem"
         if len(concepts) > 100:
             self.generate_enum = False

--- a/fhirspec.py
+++ b/fhirspec.py
@@ -78,6 +78,7 @@ class FHIRSpec(object):
                 ## http://hl7.org/fhir/2018Jan/valueset-operation-outcome.html <- bad build of the FHIR spec for R4 snapshot
                 if len(self.codesystems) > 0:
                     self.codesystems[resource['url']] = FHIRCodeSystem(self, resource)
+                else: logger.warn("ValueSet with 0 codes: {}".format(resource['url']))
         logger.info("Found {} ValueSets and {} CodeSystems".format(len(self.valuesets), len(self.codesystems)))
     
     def valueset_with_uri(self, uri):
@@ -187,16 +188,16 @@ class FHIRSpec(object):
             return None
         return self.settings.replacemap.get(classname, classname)
     
-    def class_name_for_profile(self, profile_names):
+    def class_name_for_profile(self, profile_name):
         # TODO need to figure out what to do with this later. Annotation author supports multiples types that caused this to fail
-        if isinstance(profile_names, (list,)) and len(profile_names) > 0:
+        if isinstance(profile_name, (list,)) and len(profile_name) > 0:
             classnames = []
-            for profile_name in profile_names:
+            for profile_name in profile_name:
                 classnames.append(self.as_class_name(profile_name.split('/')[-1]))  # may be the full Profile URI, like http://hl7.org/fhir/Profile/MyProfile
             return classnames
-        if not profile_names:
+        if not profile_name:
             return None
-        type_name = profile_names.split('/')[-1]     # may be the full Profile URI, like http://hl7.org/fhir/Profile/MyProfile
+        type_name = profile_name.split('/')[-1]     # may be the full Profile URI, like http://hl7.org/fhir/Profile/MyProfile
         return self.as_class_name(type_name)
     
     def class_name_is_native(self, class_name):
@@ -347,7 +348,6 @@ class FHIRCodeSystem(object):
         self.spec = spec
         self.definition = resource
         self.url = resource.get('url')
-
         if self.url in self.spec.settings.enum_namemap:
             self.name = self.spec.settings.enum_namemap[self.url]
         else:
@@ -364,12 +364,12 @@ class FHIRCodeSystem(object):
                 .format(self.url, resource['content']))
             return
         assert concepts, "Expecting at least one code for \"complete\" CodeSystem"
-        if len(concepts) > 100:
+        if len(concepts) > 200:
             self.generate_enum = False
-            logger.info("Will not generate enum for CodeSystem \"{}\" because it has > 100 ({}) concepts"
+            logger.info("Will not generate enum for CodeSystem \"{}\" because it has > 200 ({}) concepts"
                 .format(self.url, len(concepts)))
             return
-        
+
         self.codes = self.parsed_codes(concepts)
     
     def parsed_codes(self, codes, prefix=None):


### PR DESCRIPTION
Adding changes for 3 issues encountered while generating classes based on the latest FHIR build.

1.) Annotation added the ability to reference (Practitioner, RelatedPerson, Patient)
2.) Address (I couldn't find it) element had a required binding, but no defined ValueSet.
3.) OperationOutcome had a ValueSet with no codes in the Jan ballot snapshot.

After the changes I was able to generate.