### PR TITLE
Add an option to avoid any download

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Use
 
 5. Create a script that copies your `mappings.py` and `settings.py` file to the root of `fhir-parser`, _cd_s into `fhir-parser` and then runs `generate.py`.
     The _generate_ script by default wants to use Python _3_, issue `python generate.py` if you don't have Python 3 yet.
-    Supply the `-f` flag to force a re-download of the spec.
+    * Supply the `-f` flag to force a re-download of the spec.
+    * Supply the `--cache-only` (`-c`) flag to deny the re-download of the spec and only use cached resources (incompatible with `-f`).
 
 > NOTE that the script currently overwrites existing files without asking and without regret.
 

--- a/fhirloader.py
+++ b/fhirloader.py
@@ -22,12 +22,14 @@ class FHIRLoader(object):
         self.base_url = settings.specification_url
         self.cache = cache
     
-    def load(self, force=False):
+    def load(self, force_download=False, force_cache=False):
         """ Makes sure all the files needed have been downloaded.
         
         :returns: The path to the directory with all our files.
         """
-        if os.path.isdir(self.cache) and force:
+        if force_download: assert not force_cache
+
+        if os.path.isdir(self.cache) and force_download:
             import shutil
             shutil.rmtree(self.cache)
         
@@ -40,6 +42,8 @@ class FHIRLoader(object):
             path = os.path.join(self.cache, local)
             
             if not os.path.exists(path):
+                if force_cache:
+                    raise Exception('Resource missing from cache: {}'.format(local))
                 logger.info('Downloading {}'.format(remote))
                 filename = self.download(remote)
                 

--- a/generate.py
+++ b/generate.py
@@ -3,6 +3,7 @@
 #
 #  Download and parse FHIR resource definitions
 #  Supply "-f" to force a redownload of the spec
+#  Supply "-c" to force using the cached spec (incompatible with "-f")
 #  Supply "-d" to load and parse but not write resources
 #  Supply "-l" to only download the spec
 
@@ -16,14 +17,15 @@ _cache = 'downloads'
 
 
 if '__main__' == __name__:
-    force = len(sys.argv) > 1 and '-f' in sys.argv
+    force_download = len(sys.argv) > 1 and '-f' in sys.argv
     dry = len(sys.argv) > 1 and ('-d' in sys.argv or '--dry-run' in sys.argv)
     load_only = len(sys.argv) > 1 and ('-l' in sys.argv or '--load-only' in sys.argv)
-    
+    force_cache = len(sys.argv) > 1 and ('-c' in sys.argv or '--cache-only' in sys.argv)
+
     # assure we have all files
     loader = fhirloader.FHIRLoader(settings, _cache)
-    spec_source = loader.load(force)
-    
+    spec_source = loader.load(force_download=force_download, force_cache=force_cache)
+
     # parse
     if not load_only:
         spec = fhirspec.FHIRSpec(spec_source, settings)


### PR DESCRIPTION
In some cases, in order to force deterministic builds, it might be
useful to force the generator to fail if the resources are not available
in the cache.