### PR TITLE
DSTU-2 Backwards compatibility and R5 support

### DIFF
--- a/Default/mappings.py
+++ b/Default/mappings.py
@@ -72,8 +72,10 @@ enum_map = {
 
 # If you want to give specific names to enums based on their URI
 enum_namemap = {
-    'http://hl7.org/fhir/contracttermsubtypecodes': 'ContractTermSubtypeCodes',
-    'http://hl7.org/fhir/coverage-exception': 'CoverageExceptionCodes',
-    'http://hl7.org/fhir/resource-type-link': 'ResourceTypeLink',
+    # 'http://hl7.org/fhir/coverage-exception': 'CoverageExceptionCodes',
 }
 
+# If certain CodeSystems don't need to generate an enum
+enum_ignore = {
+    # 'http://hl7.org/fhir/resource-type-link',
+}

--- a/Default/settings.py
+++ b/Default/settings.py
@@ -10,6 +10,9 @@ from Default.mappings import *
 specification_url = 'http://hl7.org/fhir/2018May/'
 #specification_url = 'http://build.fhir.org'
 
+# To which directory to download to
+download_directory = 'downloads'
+
 # In which directory to find the templates. See below for settings that start with `tpl_`: these are the template names.
 tpl_base = 'Sample'
 
@@ -19,7 +22,7 @@ tpl_resource_source = 'template-resource.py'          # the template to use as s
 tpl_resource_target = '../models'                     # target directory to write the generated class files to
 tpl_resource_target_ptrn = '{}.py'                    # target class file name pattern, with one placeholder (`{}`) for the class name
 tpl_codesystems_source = 'template-codesystems.py'    # the template to use as source when writing enums for CodeSystems; can be `None`
-tpl_codesystems_target_name = 'codesystems.py'        # the filename to use for the generated code systems and value sets (in `tpl_resource_target`)
+tpl_codesystems_target_ptrn = 'codesystem_{}.py'      # the filename pattern to use for generated code systems and value sets, with one placeholder (`{}`) for the class name
 
 # Whether and where to put the factory methods and the dependency graph
 write_factory = True

--- a/Sample/template-codesystems.py
+++ b/Sample/template-codesystems.py
@@ -8,7 +8,7 @@
 #  THIS HAS BEEN ADAPTED FROM Swift Enums WITHOUT EVER BEING IMPLEMENTED IN
 #  Python, FOR DEMONSTRATION PURPOSES ONLY.
 #
-{% for system in systems %}{% if system.generate_enum %}
+{% if system.generate_enum %}
 
 class {{ system.name }}(object) {
 	""" {{ system.definition.description|wordwrap(width=120, wrapstring="\n") }}
@@ -25,4 +25,4 @@ class {{ system.name }}(object) {
 	"""
 	{%- endfor %}
 }
-{% endif %}{% endfor %}
+{% endif %}

--- a/Sample/template-elementfactory.py
+++ b/Sample/template-elementfactory.py
@@ -3,6 +3,9 @@
 #
 #  Generated from FHIR {{ info.version }} on {{ info.date }}.
 #  {{ info.year }}, SMART Health IT.
+#
+#  THIS TEMPLATE IS FOR ILLUSTRATIVE PURPOSES ONLY, YOU NEED TO CREATE YOUR OWN
+#  WHEN USING fhir-parser.
 
 
 class FHIRElementFactory(object):

--- a/Sample/template-resource.py
+++ b/Sample/template-resource.py
@@ -3,6 +3,9 @@
 #
 #  Generated from FHIR {{ info.version }} ({{ profile.url }}) on {{ info.date }}.
 #  {{ info.year }}, SMART Health IT.
+#
+#  THIS TEMPLATE IS FOR ILLUSTRATIVE PURPOSES ONLY, YOU NEED TO CREATE YOUR OWN
+#  WHEN USING fhir-parser.
 
 {%- set imported = {} %}
 {%- for klass in classes %}

--- a/Sample/template-unittest.py
+++ b/Sample/template-unittest.py
@@ -3,6 +3,9 @@
 #
 #  Generated from FHIR {{ info.version }} on {{ info.date }}.
 #  {{ info.year }}, SMART Health IT.
+#
+#  THIS TEMPLATE IS FOR ILLUSTRATIVE PURPOSES ONLY, YOU NEED TO CREATE YOUR OWN
+#  WHEN USING fhir-parser.
 
 
 import os

--- a/fhirloader.py
+++ b/fhirloader.py
@@ -17,10 +17,10 @@ class FHIRLoader(object):
         'profiles-resources.json': 'examples-json.zip',
     }
     
-    def __init__(self, settings, cache):
+    def __init__(self, settings):
         self.settings = settings
         self.base_url = settings.specification_url
-        self.cache = cache
+        self.cache = os.path.join(*settings.download_directory.split('/'))
     
     def load(self, force_download=False, force_cache=False):
         """ Makes sure all the files needed have been downloaded.

--- a/fhirrenderer.py
+++ b/fhirrenderer.py
@@ -149,13 +149,17 @@ class FHIRValueSetRenderer(FHIRRenderer):
             return
         
         systems = [v for k,v in self.spec.codesystems.items()]
-        data = {
-            'info': self.spec.info,
-            'systems': sorted(systems, key=lambda x: x.name),
-        }
-        target_name = self.settings.tpl_codesystems_target_name
-        target_path = os.path.join(self.settings.tpl_resource_target, target_name)
-        self.do_render(data, self.settings.tpl_codesystems_source, target_path)
+        for system in sorted(systems, key=lambda x: x.name):
+            if not system.generate_enum:
+                continue
+            
+            data = {
+                'info': self.spec.info,
+                'system': system,
+            }
+            target_name = self.settings.tpl_codesystems_target_ptrn.format(system.name)
+            target_path = os.path.join(self.settings.tpl_resource_target, target_name)
+            self.do_render(data, self.settings.tpl_codesystems_source, target_path)
 
 
 class FHIRUnitTestRenderer(FHIRRenderer):

--- a/generate.py
+++ b/generate.py
@@ -13,8 +13,6 @@ import settings
 import fhirloader
 import fhirspec
 
-_cache = 'downloads'
-
 
 if '__main__' == __name__:
     force_download = len(sys.argv) > 1 and '-f' in sys.argv
@@ -23,7 +21,7 @@ if '__main__' == __name__:
     force_cache = len(sys.argv) > 1 and ('-c' in sys.argv or '--cache-only' in sys.argv)
 
     # assure we have all files
-    loader = fhirloader.FHIRLoader(settings, _cache)
+    loader = fhirloader.FHIRLoader(settings)
     spec_source = loader.load(force_download=force_download, force_cache=force_cache)
 
     # parse


### PR DESCRIPTION
Introduce backwards compatibility for DSTU-2 codesystem/enum generation. Add R5 support.

- Detect "structuredefinition-fhir-type", introduced after R4
- Expose enum-cased resource type name
- Make enum generation work with DSTU-2
- BREAKING: make name_of_resource only return not-None for actual resources
- BREAKING changes to code system handling
    - Write one file per enum being generated, rather than putting them all into one file
    - Also create FHIRClass instances for enums/codesystems
    - Expose convenience accessors on FHIRClass for easier generation
- Allow to configure download target directory
- DSTU-2 backwards compatibility: detect Element references for class name determination