### PR TITLE
Add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: python
+script:
+  - echo "from Default.settings import *" > settings.py
+  - ./generate.py

--- a/Default/mappings.py
+++ b/Default/mappings.py
@@ -63,6 +63,7 @@ reservedmap = {
 # For enum codes where a computer just cannot generate reasonable names
 enum_map = {
     '=': 'eq',
+    '!=': 'ne',
     '<': 'lt',
     '<=': 'lte',
     '>': 'gt',

--- a/Default/settings.py
+++ b/Default/settings.py
@@ -8,7 +8,6 @@ from Default.mappings import *
 
 # Base URL for where to load specification data from
 specification_url = 'http://hl7.org/fhir/R4'
-#specification_url = 'http://hl7.org/fhir/2018May/'
 #specification_url = 'http://build.fhir.org'
 
 # To which directory to download to

--- a/Default/settings.py
+++ b/Default/settings.py
@@ -7,7 +7,8 @@ from Default.mappings import *
 
 
 # Base URL for where to load specification data from
-specification_url = 'http://hl7.org/fhir/2018May/'
+specification_url = 'http://hl7.org/fhir/R4'
+#specification_url = 'http://hl7.org/fhir/2018May/'
 #specification_url = 'http://build.fhir.org'
 
 # To which directory to download to

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Python FHIR Parser
 ==================
+[![Build Status](https://travis-ci.org/palfrey/fhir-parser.svg?branch=master)](https://travis-ci.org/palfrey/fhir-parser)
 
 A Python FHIR specification parser for model class generation.
 If you've come here because you want _Swift_ or _Python_ classes for FHIR data models, look at our client libraries instead:

--- a/fhirunittest.py
+++ b/fhirunittest.py
@@ -147,7 +147,8 @@ class FHIRUnitTestItem(object):
     
     def __init__(self, filepath, path, value, klass, array_item, enum_item):
         assert path
-        assert value is not None
+        if filepath.find("plandefinition-example-cardiology-os") == -1: # this example has a null value
+            assert value is not None, (filepath, path)
         assert klass
         self.filepath = filepath        # needed for debug logging
         self.path = path

--- a/fhirunittest.py
+++ b/fhirunittest.py
@@ -147,8 +147,7 @@ class FHIRUnitTestItem(object):
     
     def __init__(self, filepath, path, value, klass, array_item, enum_item):
         assert path
-        if filepath.find("plandefinition-example-cardiology-os") == -1: # this example has a null value
-            assert value is not None, (filepath, path)
+        assert value is not None, (filepath, path)
         assert klass
         self.filepath = filepath        # needed for debug logging
         self.path = path

--- a/fhirunittest.py
+++ b/fhirunittest.py
@@ -154,7 +154,7 @@ class FHIRUnitTestItem(object):
         self.value = value
         self.klass = klass
         self.array_item = array_item
-        self.enum = enum_item['name'] if enum_item is not None else None
+        self.enum = enum_item.name if enum_item is not None else None
     
     def create_tests(self, controller):
         """ Creates as many FHIRUnitTestItem instances as the item defines, or


### PR DESCRIPTION
Mostly to fix/test the out-of-the-box scenario (i.e. #39). This PR:

- Adds Travis CI (and a build badge that will need pointing to here, not my fork, once that gets enabled).
- Fixes the "ne" case in mappings
- And FHIRUnitTestItem's use of enum name
- ~~Adds an exception for null values for plandefinition-example-cardiology-os as that file has that broken data, and I'm guessing that's just fine, right?~~ Updated default download spec to R4 so we have working tests.

See https://travis-ci.org/github/palfrey/fhir-parser/builds/714539338 for working demo build